### PR TITLE
CCD0 Expansion

### DIFF
--- a/src/ccd/model/AbstractCCD.java
+++ b/src/ccd/model/AbstractCCD.java
@@ -56,6 +56,9 @@ public abstract class AbstractCCD implements ITreeDistribution {
     /** Threshold used for throwing error when probability that much out of bounds (mostly above 1). */
     public final static double PROBABILITY_ERROR = 1e-5;
 
+    /** Whether to use log probabilities instead of probabilities; necessary for huge/diffuse CCDs. */
+    protected boolean useLogProbabilities = false;
+
     /**
      * The trees this CCD is based on (burnin trees removed).
      */
@@ -1196,6 +1199,13 @@ public abstract class AbstractCCD implements ITreeDistribution {
 
 
     /* -- PROBABILITY - PROBABILITY -- */
+
+    protected void setToUseLogProbabilities() {
+        this.useLogProbabilities = true;
+    }
+    protected boolean useLogProbabilities() {
+        return useLogProbabilities;
+    }
 
     @Override
     public double getProbabilityOfTree(Tree tree) {

--- a/src/ccd/model/AbstractCCD.java
+++ b/src/ccd/model/AbstractCCD.java
@@ -1394,13 +1394,7 @@ public abstract class AbstractCCD implements ITreeDistribution {
      */
     public void resetSumCladeCredibilities() {
         for (Clade clade : this.getClades()) {
-            if (clade.isLeaf()) {
-                clade.setSumCladeCredibilities(1);
-            } else if (clade.isCherry()) {
-                clade.setSumCladeCredibilities(clade.getCladeCredibility());
-            } else {
-                clade.setSumCladeCredibilities(-1);
-            }
+            clade.resetSumCladeCredibilities();
         }
     }
 

--- a/src/ccd/model/CCD0.java
+++ b/src/ccd/model/CCD0.java
@@ -300,9 +300,8 @@ public class CCD0 extends AbstractCCD {
             try {
                 setPartitionProbabilities(this.rootClade);
             } catch (UnderflowException exception) {
-                // an underflow has occurred
-                // we try again in log space
                 System.err.println("An underflow was detected. We switch to log space.");
+                this.resetSumCladeCredibilities();
                 setPartitionLogProbabilities(this.rootClade);
             }
 
@@ -454,14 +453,14 @@ public class CCD0 extends AbstractCCD {
 
         // otherwise we check if we find a larger partner clade for any
         // smaller clade that together partition the parent clade;
-        for (int j = 1; j <= parent.size() / 2; j++) {
-            for (Clade smallChild : cladeBuckets.get(j - 1)) {
-                if (done.contains(smallChild)) {
+        for (int j = (int) Math.ceil(parent.size() / 2); j < parent.size(); j++) {
+            for (Clade largeChild : cladeBuckets.get(j - 1)) {
+                if (done.contains(largeChild)) {
                     continue;
                 }
 
-                BitSet smallChildBits = smallChild.getCladeInBits();
-                findPartitionHelper(smallChild, parent, helperBits, parentBits, smallChildBits);
+                BitSet largerChildBits = largeChild.getCladeInBits();
+                findPartitionHelper(largeChild, parent, helperBits, parentBits, largerChildBits);
             }
         }
 
@@ -598,6 +597,7 @@ public class CCD0 extends AbstractCCD {
             // a leaf has no partition, sum of probabilities is 1
             clade.setLogSumCladeCredibilities(0);
             return 0.0;
+
         } else if (clade.isCherry()) {
             // a cherry has only one partition
             if (clade.partitions.isEmpty()) {
@@ -606,6 +606,7 @@ public class CCD0 extends AbstractCCD {
             clade.partitions.get(0).setCCP(1);
             clade.setLogSumCladeCredibilities(logCladeValue);
             return logCladeValue;
+
         } else {
             // other might have more partitions
             double sumSubtreeProbabilities = 0.0;

--- a/src/ccd/model/Clade.java
+++ b/src/ccd/model/Clade.java
@@ -102,6 +102,11 @@ public class Clade {
     private double sumCladeCredibilities = -1;
 
     /**
+     * The log of sum of subtree clade credibilities of all trees rooted at this clade.
+     */
+    private double sumLogCladeCredibilities = 1;
+
+    /**
      * The probability of this clade appearing in a tree of the respective
      * distribution.
      */
@@ -300,6 +305,7 @@ public class Clade {
             this.maxSubtreeSumCladeCredibility = -1;
             this.entropy = -1;
             this.sumCladeCredibilities = -1;
+            this.sumLogCladeCredibilities = 1;
             this.probability = -1;
 
             for (CladePartition partition : partitions) {
@@ -551,17 +557,17 @@ public class Clade {
         }
 
         for (Clade parent : this.getParentClades()) {
-            parent.collectAncostorClades(ancestors);
+            parent.collectAncestorClades(ancestors);
         }
 
         return ancestors;
     }
 
     /* Recursive (upward) helper method */
-    private void collectAncostorClades(Set<Clade> ancestors) {
+    private void collectAncestorClades(Set<Clade> ancestors) {
         if (ancestors.add(this)) {
             for (Clade parent : this.getParentClades()) {
-                parent.collectAncostorClades(ancestors);
+                parent.collectAncestorClades(ancestors);
             }
         }
     }
@@ -804,7 +810,39 @@ public class Clade {
      *              this clade
      */
     public void setSumCladeCredibilities(double value) {
+        if (value < 0) {
+            throw new AssertionError("Sum clade credibilities cannot be negative, but requested value to set is: " + value);
+        }
         this.sumCladeCredibilities = value;
+    }
+
+    /**
+     * Reset the sum of clade credibilities to the default un-computed value of -1 (for non-leaf non-cherry clades).
+     */
+    public void resetSumCladeCredibilities() {
+        if (this.isLeaf()) {
+            this.sumCladeCredibilities = 1;
+        } else {
+            this.sumCladeCredibilities = -1;
+        }
+    }
+
+    /**
+     * @return if computed, log of sum of subtree clade credibilities of all subtrees rooted at this clade
+     */
+    public double getLogSumCladeCredibilities() {
+        return this.sumLogCladeCredibilities;
+    }
+
+    /**
+     * @param value sum of subtree clade credibilities of all subtrees rooted at
+     *              this clade
+     */
+    public void setLogSumCladeCredibilities(double value) {
+        if (value > 0) {
+            throw new AssertionError("Log probabilities must be non-positive.");
+        }
+        this.sumLogCladeCredibilities = value;
     }
 
     /**

--- a/src/ccd/model/UnderflowException.java
+++ b/src/ccd/model/UnderflowException.java
@@ -1,0 +1,7 @@
+package ccd.model;
+
+public class UnderflowException extends ArithmeticException {
+    public UnderflowException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
These commit adds changes to the CCD0 implementation.

General improvements:

- When we look at all possible children of a parent clade in order to find its splits, we now loop through the possible larger children. This leads to a performance improvement as empirically, we have seen that the clades are skewed towards smaller sizes.
- Setting the clade split CCPs in CCD0 is now completely done in log-space if an underflow is detected.

A simple way to limit the expansion of the CCD if needed is implemented:

- Instead of looking at all clades when expanding the CCD1 graph, we only consider the most frequent clades as parents and as the larger child of a split to add.
- The expansion is parameterized by a factor `maxExpansionFactor`. `maxExpansionFactor` times the number of taxa corresponds to the actual number of clades that are considered. This was chosen as it seems to be a reasonable dataset-agnostic heuristic.