### PR TITLE
Fix underflow for large trees

### DIFF
--- a/src/ccd/model/AbstractCCD.java
+++ b/src/ccd/model/AbstractCCD.java
@@ -931,12 +931,26 @@ public abstract class AbstractCCD implements ITreeDistribution {
         return vertex;
     }
 
+    /**
+     * Returns the probability of the most likely tree. Note that this can
+     * underflow for large trees. It is recommended to use {@link #getMaxLogTreeProbability()}
+     * instead.
+     *
+     * @return probability of the most likely tree.
+     */
     @Override
     public double getMaxTreeProbability() {
+        return Math.exp(this.getMaxLogTreeProbability());
+    }
+
+    /**
+     * @return the log probability of the most likely tree.
+     */
+    public double getMaxLogTreeProbability() {
         tidyUpCacheIfDirty();
         resetCacheIfProbabilitiesDirty();
 
-        return this.rootClade.getMaxSubtreeCCP();
+        return this.rootClade.getMaxSubtreeLogCCP();
     }
 
     /* Helper method */

--- a/src/ccd/model/AbstractCCD.java
+++ b/src/ccd/model/AbstractCCD.java
@@ -959,16 +959,6 @@ public abstract class AbstractCCD implements ITreeDistribution {
         switch (samplingStrategy) {
             case MAP: {
                 partition = clade.getMaxSubtreeCCPPartition();
-
-                // check if partition tied with others
-                /*-
-                ArrayList<CladePartition> partitions = clade.getPartitions();
-                for (CladePartition cladePartition : partitions) {
-                    if ((cladePartition != partition)
-                            && (cladePartition.getMaxSubtreeCCP() == partition.getMaxSubtreeCCP())) {
-                        out.println(" -!- tie in choice of max recursive probability tree");
-                    }
-                }*/
                 break;
             }
             case Sampling: {

--- a/src/ccd/model/AbstractCCD.java
+++ b/src/ccd/model/AbstractCCD.java
@@ -56,9 +56,6 @@ public abstract class AbstractCCD implements ITreeDistribution {
     /** Threshold used for throwing error when probability that much out of bounds (mostly above 1). */
     public final static double PROBABILITY_ERROR = 1e-5;
 
-    /** Whether to use log probabilities instead of probabilities; necessary for huge/diffuse CCDs. */
-    protected boolean useLogProbabilities = false;
-
     /**
      * The trees this CCD is based on (burnin trees removed).
      */
@@ -1199,13 +1196,6 @@ public abstract class AbstractCCD implements ITreeDistribution {
 
 
     /* -- PROBABILITY - PROBABILITY -- */
-
-    protected void setToUseLogProbabilities() {
-        this.useLogProbabilities = true;
-    }
-    protected boolean useLogProbabilities() {
-        return useLogProbabilities;
-    }
 
     @Override
     public double getProbabilityOfTree(Tree tree) {

--- a/src/ccd/model/CCD0.java
+++ b/src/ccd/model/CCD0.java
@@ -318,18 +318,12 @@ public class CCD0 extends AbstractCCD {
         // then need to set clade partition probabilities
         // which normalizes the product of clade probabilities
         // out.print("setting probabilities ... ");
-        if (this.useLogProbabilities) {
+        try {
+            setPartitionProbabilities(this.rootClade);
+        } catch (UnderflowException exception) {
+            System.err.println("An underflow was detected. We switch to log space.");
+            this.resetSumCladeCredibilities();
             setPartitionLogProbabilities(this.rootClade);
-        } else {
-
-            try {
-                setPartitionProbabilities(this.rootClade);
-            } catch (UnderflowException exception) {
-                System.err.println("An underflow was detected. We switch to log space.");
-                this.resetSumCladeCredibilities();
-                setPartitionLogProbabilities(this.rootClade);
-            }
-
         }
 
         // out.println(" ...done.");

--- a/src/ccd/model/Clade.java
+++ b/src/ccd/model/Clade.java
@@ -693,7 +693,7 @@ public class Clade {
         for (CladePartition partition : partitions) {
             double partitionMaxLogCCP = partition.getMaxSubtreeLogCCP();
 
-            if (partitionMaxLogCCP > maxSubtreeLogCCP) {
+            if (partitionMaxLogCCP > maxSubtreeLogCCP || maxSubtreeLogCCP > 0) {
                 maxSubtreeLogCCP = partitionMaxLogCCP;
                 maxSubtreeCCPPartition = partition;
             } else if (partitionMaxLogCCP == maxSubtreeLogCCP) {

--- a/src/ccd/model/Clade.java
+++ b/src/ccd/model/Clade.java
@@ -76,7 +76,7 @@ public class Clade {
     /**
      * Computed max CCP of any subtree with the root on this clade.
      */
-    private double maxSubtreeCCP = -1;
+    private double maxSubtreeLogCCP = 1;
 
     /**
      * The partition of this clade realized by the subtree rooted at this clade
@@ -141,7 +141,7 @@ public class Clade {
         this.childClades = new ArrayList<Clade>(8);
 
         if (size == 1) {
-            this.maxSubtreeCCP = 1;
+            this.maxSubtreeLogCCP = 0;
             this.maxSubtreeSumCladeCredibility = 1;
             this.probability = 1;
             this.sumCladeCredibilities = 1;
@@ -301,7 +301,7 @@ public class Clade {
                 this.maxSubtreeSumCladeCredibilityPartition = null;
                 this.numTopologies = null;
             }
-            this.maxSubtreeCCP = -1;
+            this.maxSubtreeLogCCP = 1;
             this.maxSubtreeSumCladeCredibility = -1;
             this.entropy = -1;
             this.sumCladeCredibilities = -1;
@@ -656,14 +656,14 @@ public class Clade {
     }
 
     /**
-     * @return max CCP of any subtree rooted at this clade
+     * @return max log CCP of any subtree rooted at this clade.
      */
-    public double getMaxSubtreeCCP() {
-        if (this.maxSubtreeCCP < 0) {
-            this.computeMaxSubtreeCCP();
+    public double getMaxSubtreeLogCCP() {
+        if (this.maxSubtreeLogCCP > 0) {
+            this.computeMaxSubtreeLogCCP();
         }
 
-        return maxSubtreeCCP;
+        return maxSubtreeLogCCP;
     }
 
     /**
@@ -674,8 +674,8 @@ public class Clade {
      * @return partition realized in max CCP subtree rooted at this clade
      */
     public CladePartition getMaxSubtreeCCPPartition() {
-        if ((this.maxSubtreeCCPPartition == null) || (this.maxSubtreeCCP < 0)) {
-            this.computeMaxSubtreeCCP();
+        if ((this.maxSubtreeCCPPartition == null) || (this.maxSubtreeLogCCP > 0)) {
+            this.computeMaxSubtreeLogCCP();
         }
 
         return maxSubtreeCCPPartition;
@@ -686,24 +686,24 @@ public class Clade {
      * maximizes the conditional clade probability; so this maximizes the
      * probability recursively.
      */
-    private void computeMaxSubtreeCCP() {
+    private void computeMaxSubtreeLogCCP() {
         // for a single non-leaf clade, to find the max probability subtree we
         // only have to pick the partition of this clade with max probability in
         // its two subtrees
         for (CladePartition partition : partitions) {
-            double partitionMaxCCP = partition.getMaxSubtreeCCP();
+            double partitionMaxLogCCP = partition.getMaxSubtreeLogCCP();
 
-            if (partitionMaxCCP > maxSubtreeCCP) {
-                maxSubtreeCCP = partitionMaxCCP;
+            if (partitionMaxLogCCP > maxSubtreeLogCCP) {
+                maxSubtreeLogCCP = partitionMaxLogCCP;
                 maxSubtreeCCPPartition = partition;
-            } else if (partitionMaxCCP == maxSubtreeCCP) {
+            } else if (partitionMaxLogCCP == maxSubtreeLogCCP) {
                 // System.out.println("Tie found for computeMaxSubtreeccd.");
                 Clade smallCladeMax = maxSubtreeCCPPartition.getSmallerChild();
                 Clade smallCladeCurrent = partition.getSmallerChild();
 
                 // we pick the more balanced partition
                 if (smallCladeMax.size() < smallCladeCurrent.size()) {
-                    maxSubtreeCCP = partitionMaxCCP;
+                    maxSubtreeLogCCP = partitionMaxLogCCP;
                     maxSubtreeCCPPartition = partition;
                 } else if (smallCladeMax.size() == smallCladeCurrent.size()) {
                     // but if they are equally balanced, then decide lexicographically which partition to pick
@@ -719,7 +719,7 @@ public class Clade {
 
                     BitSet bitsSmaller = BitSetUtil.getLexicographicFirst(bitsMax, bitsCurrent);
                     if (bitsCurrent == bitsSmaller) {
-                        maxSubtreeCCP = partitionMaxCCP;
+                        maxSubtreeLogCCP = partitionMaxLogCCP;
                         maxSubtreeCCPPartition = partition;
                     }
                 }

--- a/src/ccd/model/CladePartition.java
+++ b/src/ccd/model/CladePartition.java
@@ -43,10 +43,10 @@ public class CladePartition {
     private double ccp = -1;
 
     /**
-     * The maximum CCP of the subtree with the root on the parent clade and that
+     * The maximum log CCP of the subtree with the root on the parent clade and that
      * realizes this partition.
      */
-    private double maxCCP = -1;
+    private double maxSubtreeLogCCP = -1;
 
     /** Number of different tree topologies with this partition at the root. */
     private BigInteger numTopologies = null;
@@ -90,7 +90,7 @@ public class CladePartition {
 
     /** Resets cached computed values. */
     public void resetCachedValues() {
-        this.maxCCP = -1;
+        this.maxSubtreeLogCCP = 1;
         this.numTopologies = null;
     }
 
@@ -371,22 +371,22 @@ public class CladePartition {
     }
 
     /**
-     * Computes and returns the maximum conditional clade probability (CCP) of
+     * Computes and returns the maximum conditional log clade probability (CCP) of
      * the subtree with the root on the parent clade and that realizes this
      * partition.
      *
-     * @return maximum probability of subtree realizing this partition
+     * @return maximum log probability of subtree realizing this partition
      */
-    public double getMaxSubtreeCCP() {
-        if (this.maxCCP < 0) {
-            maxCCP = this.getCCP();
+    public double getMaxSubtreeLogCCP() {
+        if (this.maxSubtreeLogCCP > 0) {
+            maxSubtreeLogCCP = this.getLogCCP();
 
             for (Clade clade : childClades) {
-                maxCCP *= clade.getMaxSubtreeCCP();
+                maxSubtreeLogCCP += clade.getMaxSubtreeLogCCP();
             }
         }
 
-        return maxCCP;
+        return maxSubtreeLogCCP;
     }
 
     /**

--- a/src/ccd/model/CladePartition.java
+++ b/src/ccd/model/CladePartition.java
@@ -46,7 +46,7 @@ public class CladePartition {
      * The maximum log CCP of the subtree with the root on the parent clade and that
      * realizes this partition.
      */
-    private double maxSubtreeLogCCP = -1;
+    private double maxSubtreeLogCCP = 1;
 
     /** Number of different tree topologies with this partition at the root. */
     private BigInteger numTopologies = null;


### PR DESCRIPTION
These commits fix a underflow leading to errors when getting point estimates for large trees.

The error occurred in the `getMaxSubtreeCCP` method in the `CladePartition` class. The method is used to calculate the CPP of the optimal subtree realizing a partition at its root. This CPP is a product of the CPPs of all partitions in a subtree. For large trees, the partition CPPs were fine, but calculating their product produced an underflow.

The problem is fixed by moving the subtree CPP calculations into log-space.

We now obtain the same point estimate (up to ties) as the Hipstr algorithm on the dataset in the Hipstr paper when running CCD0 with no expansion.

Some caveats:

- Note that the method `getMaxTreeProbability` in the `AbstractCCD` class (and all its descendants) returns the non-log probability and can thus still underflow. Code that uses it should be changed to use `getMaxLogTreeProbability` in a future update.
- This fix only improves point estimates. For large trees, `getProbabilityOfTree` in the `AbstractCCD` class will potentially underflow as well. This should be addressed in a future change.

Other minor changes:

- In `CCD0`, we now only switch to log-space for normalization if an underflow has been detected. Because of that, the field `useLogProbabilities` and its getter and setter have been removed.