### PR TITLE
Add KRegCCD regularisation family, UniformEscapeCCD, and PIT/held-out experiments

### DIFF
--- a/src/main/java/ccd/algorithms/LoadOrStoreTrees.java
+++ b/src/main/java/ccd/algorithms/LoadOrStoreTrees.java
@@ -1,0 +1,316 @@
+package ccd.algorithms;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import beast.base.parser.NexusParser;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+
+public class LoadOrStoreTrees {
+
+    public static List<Tree> loadTrees(File treeFile, double burninPercentage) throws IOException {
+        NexusParser parser = new NexusParser();
+        parser.parseFile(treeFile);
+        System.out.println("loading tree file: " + treeFile);
+        List<Tree> fullTreeList = parser.trees;
+        List<Tree> treesToUse;
+        if (burninPercentage == 0) {
+            treesToUse = fullTreeList;
+        } else {
+            int numDiscardedTrees = (int) (fullTreeList.size() * burninPercentage);
+            int numUsedTrees = fullTreeList.size() - numDiscardedTrees;
+            treesToUse = new ArrayList<Tree>(numUsedTrees);
+            treesToUse.addAll(fullTreeList.subList(numDiscardedTrees, fullTreeList.size()));
+        }
+        return treesToUse;
+    }
+
+    /**
+     * Loads at most {@code sampleCount} trees, thinned evenly across the post-burnin chain, parsing
+     * <em>only</em> the sampled trees: the Newick strings of the trees in between are read past in the
+     * reader but never handed to the {@link TreeParser}, which is the expensive step. This is the
+     * streaming counterpart of {@link #loadTrees(File, double)} followed by even thinning -- it
+     * returns the same trees, at the same indices, but skips building the discarded ones.
+     *
+     * <p>The thinning matches the in-memory idiom: with {@code total} trees in the file, the first
+     * {@code floor(total * burnin)} are burn-in; of the remaining {@code usable} trees, tree
+     * {@code numDiscarded + floor(i * usable / sampleCount)} is taken for {@code i = 0..sampleCount-1}.
+     * If {@code usable <= sampleCount} every post-burnin tree is returned (nothing is thinned).
+     *
+     * <p>Two streaming passes are made over the file: the first counts the trees (no Newick parsing)
+     * to fix {@code total}, the second parses only the selected indices. Both passes use one shared
+     * command reader so the indices line up exactly.
+     */
+    public static List<Tree> loadTrees(File treeFile, double burninPercentage, int sampleCount)
+            throws IOException {
+        if (sampleCount <= 0) {
+            throw new IllegalArgumentException("sampleCount must be positive, got " + sampleCount);
+        }
+        System.out.println("loading tree file: " + treeFile + " (subsampling up to " + sampleCount
+                + " of the post-burnin trees, skipping the rest in the reader)");
+        SubsamplingNexusParser parser = new SubsamplingNexusParser();
+
+        // Pass 1: count trees without parsing any Newick, so even thinning has the true total.
+        int total = parser.streamTreesBlock(treeFile, null, null);
+
+        int numDiscarded = (int) (total * burninPercentage);
+        int usable = total - numDiscarded;
+        BitSet wanted = new BitSet(total);
+        if (usable <= sampleCount) {
+            wanted.set(numDiscarded, total);
+        } else {
+            double step = (double) usable / sampleCount;
+            for (int i = 0; i < sampleCount; i++) {
+                wanted.set(numDiscarded + (int) (i * step));
+            }
+        }
+
+        // Pass 2: parse only the selected trees.
+        List<Tree> trees = new ArrayList<>(wanted.cardinality());
+        parser.streamTreesBlock(treeFile, wanted, trees);
+        return trees;
+    }
+
+    /**
+     * A {@link NexusParser} that can stream the trees block, parsing only a chosen subset of trees.
+     * It reuses the superclass's translate/taxa handling (so a tree set with or without a translate
+     * block parses exactly as {@link NexusParser} would) and replicates only the small command reader,
+     * which is package-private in {@link NexusParser} and so not otherwise reachable.
+     */
+    private static final class SubsamplingNexusParser extends NexusParser {
+
+        /**
+         * Streams the trees block of {@code treeFile}. Every {@code tree} command is counted; a tree
+         * whose zero-based index is set in {@code wanted} is parsed into a {@link Tree} and appended to
+         * {@code out}. When {@code wanted} is {@code null} nothing is parsed (a pure count pass).
+         *
+         * @return the total number of trees in the file
+         */
+        int streamTreesBlock(File treeFile, BitSet wanted, List<Tree> out) throws IOException {
+            try (BufferedReader fin = new BufferedReader(new FileReader(treeFile))) {
+                lineNr = 0;
+                // Advance to the trees block, parsing any preceding taxa block (needed for taxon names
+                // when there is no translate block), exactly as NexusParser.parseFile does.
+                String line;
+                while ((line = nextLine(fin)) != null) {
+                    String lower = line.toLowerCase();
+                    if (lower.matches("^\\s*begin\\s+taxa;\\s*$")) {
+                        parseTaxaBlock(fin);
+                    } else if (lower.matches("^\\s*begin\\s+trees;\\s*$")) {
+                        // The header (taxa block, block starts) is tiny; the trees block is the bulk of
+                        // a multi-MB file, so read it through a chunked buffer rather than the per-char
+                        // (synchronized) BufferedReader.read() that otherwise dominates parse time.
+                        return readTrees(new FastCharReader(fin), wanted, out);
+                    }
+                }
+            }
+            return 0;
+        }
+
+        private int readTrees(FastCharReader fin, BitSet wanted, List<Tree> out) throws IOException {
+            int origin = -1;
+            List<String> blockTaxa = this.taxa;
+
+            String command = readCommand(fin);
+            // optional translate block, parsed once up front
+            if (command != null && commandName(command).equals("translate")) {
+                Map<String, String> translationMap = parseTranslateCommand(commandArgs(command));
+                origin = getIndexedTranslationMapOrigin(translationMap);
+                if (origin != -1) {
+                    blockTaxa = getIndexedTranslationMap(translationMap, origin);
+                }
+                command = readCommand(fin);
+            }
+
+            int current = 0;
+            for (; command != null; command = readCommand(fin)) {
+                // Only the command name is needed to classify; the full (whitespace-normalised)
+                // arguments are extracted lazily, i.e. only for the trees actually being parsed.
+                String name = commandName(command);
+                if (name.equals("end")) {
+                    break;
+                }
+                if (name.equals("tree")) {
+                    if (wanted != null && wanted.get(current)) {
+                        out.add(parseTree(commandArgs(command), blockTaxa, origin, current));
+                    }
+                    current++;
+                }
+            }
+            return current;
+        }
+
+        /** Mirrors NexusParser.parseTreesBlock's per-tree handling for a single selected tree. */
+        private Tree parseTree(String treeString, List<String> blockTaxa, int origin, int current) {
+            int i = treeString.indexOf('(');
+            String id = "" + current;
+            try {
+                id = treeString.substring(5, i).split("=")[0].trim();
+            } catch (Exception e) {
+                // ignore, keep the index as id
+            }
+            if (i > 0) {
+                treeString = treeString.substring(i);
+            }
+            TreeParser treeParser;
+            if (origin != -1) {
+                treeParser = new TreeParser(blockTaxa, treeString, origin, false);
+            } else {
+                try {
+                    treeParser = new TreeParser(blockTaxa, treeString, 0, false);
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    treeParser = new TreeParser(blockTaxa, treeString, 1, false);
+                }
+            }
+            treeParser.setID(id);
+            return treeParser;
+        }
+
+        /* ---- replicated command reader (NexusParser's is package-private) ---- */
+
+        /**
+         * Reads the next nexus command: characters up to the terminating {@code ;}, with nexus
+         * comments ({@code [...]}) and quoted strings read through verbatim. Returns {@code null} at
+         * end of file. Mirrors {@link NexusParser}'s {@code readNextCommand}.
+         */
+        private String readCommand(FastCharReader fin) throws IOException {
+            StringBuilder sb = new StringBuilder();
+            int nextVal;
+            while ((nextVal = fin.read()) >= 0) {
+                char c = (char) nextVal;
+                if (c == ';') {
+                    break;
+                }
+                sb.append(c);
+                switch (c) {
+                    case '[' -> readComment(fin, sb);
+                    case '"', '\'' -> readString(fin, sb, c);
+                    case '\n' -> lineNr += 1;
+                    default -> {
+                    }
+                }
+            }
+            return sb.toString().isEmpty() ? null : sb.toString();
+        }
+
+        private void readComment(FastCharReader fin, StringBuilder sb) throws IOException {
+            int nextVal;
+            while ((nextVal = fin.read()) >= 0) {
+                char c = (char) nextVal;
+                sb.append(c);
+                if (c == ']') {
+                    return;
+                }
+                if (c == '"' || c == '\'') {
+                    readString(fin, sb, c);
+                }
+                if (c == '\n') {
+                    lineNr += 1;
+                }
+            }
+            throw new IOException("Unterminated comment.");
+        }
+
+        private void readString(FastCharReader fin, StringBuilder sb, char delim) throws IOException {
+            int nextVal;
+            while ((nextVal = fin.read()) >= 0) {
+                char c = (char) nextVal;
+                sb.append(c);
+                if (c == delim) {
+                    return;
+                }
+                if (c == '\n') {
+                    lineNr += 1;
+                }
+            }
+            throw new IOException("Unterminated string.");
+        }
+
+        /**
+         * Pulls characters from an underlying {@link Reader} through a large in-memory buffer. The
+         * nexus command reader consumes the trees block one character at a time; doing that straight
+         * off a {@link BufferedReader} pays the per-call cost of its {@code synchronized} {@code read()}
+         * (plus bounds work) on every character, which dominated parse time on multi-MB tree files.
+         * Here one {@code read(char[])} refills ~64k characters, so that cost is paid ~once per 64k
+         * characters instead of once per character. Behaviour is otherwise identical: same characters,
+         * same order. Not thread-safe (one instance per parse pass).
+         */
+        private static final class FastCharReader {
+            private final Reader in;
+            private final char[] buf = new char[1 << 16];
+            private int pos = 0;
+            private int len = 0;
+
+            FastCharReader(Reader in) {
+                this.in = in;
+            }
+
+            /** @return the next character, or -1 at end of stream. */
+            int read() throws IOException {
+                if (pos >= len) {
+                    len = in.read(buf);
+                    pos = 0;
+                    if (len <= 0) {
+                        return -1;
+                    }
+                }
+                return buf[pos++];
+            }
+        }
+
+        /**
+         * Command name: the first whitespace-delimited token, lower-cased -- matching the {@code command}
+         * field of {@link NexusParser}'s NexusCommand. Scanned directly (no whitespace normalisation of
+         * the whole command) so classifying a skipped tree does not touch its Newick string.
+         */
+        private static String commandName(String command) {
+            int n = command.length(), i = 0;
+            while (i < n && Character.isWhitespace(command.charAt(i))) i++;
+            int start = i;
+            while (i < n && !Character.isWhitespace(command.charAt(i))) i++;
+            return command.substring(start, i).toLowerCase();
+        }
+
+        /**
+         * Command arguments: everything after the command token, with internal whitespace collapsed to
+         * single spaces -- matching the {@code arguments} field of {@link NexusParser}'s NexusCommand.
+         */
+        private static String commandArgs(String command) {
+            String trimmed = command.trim().replaceAll("\\s+", " ");
+            String name = trimmed.split(" ")[0];
+            return trimmed.length() > name.length() + 1 ? trimmed.substring(name.length() + 1) : "";
+        }
+    }
+
+    // TreeAnnotator.MemoryFriendlyTreeSet treeSet = new TreeAnnotator().new MemoryFriendlyTreeSet(treeFile.getAbsolutePath(), 10);
+    // AbstractCCD initialCCD1 = new CCD1(treeSet, false);  // Create initial CCD1 object
+
+    public static void storeTrees(List<Tree> trees, File treeFile) throws FileNotFoundException {
+        try (PrintStream handle = new PrintStream(treeFile)) {
+
+            trees.get(0).init(handle); // Write header info
+            handle.println(); // Ensure the semicolon before the first tree is on its own line
+
+            for (int i = 0; i < trees.size(); i++) {
+                Tree tree = trees.get(i);
+
+                int id = (tree.getID() == null) ? i : Integer.parseInt(tree.getID().replace("_", ""));
+                tree.log(id, handle);
+
+                handle.println(); // blank line between trees
+            }
+
+            trees.get(trees.size() - 1).close(handle);
+        }
+    }
+}

--- a/src/main/java/ccd/algorithms/NNICladeExpansion.java
+++ b/src/main/java/ccd/algorithms/NNICladeExpansion.java
@@ -1,0 +1,873 @@
+package ccd.algorithms;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.model.AbstractCCD;
+import ccd.model.CCD0;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import ccd.model.bitsets.BitSet;
+import ccd.tools.CCDToolUtil;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Clade-level NNI expansion of a CCD: the analogue of the CCD0 split expansion
+ * ({@link ccd.model.CCD0#expand()}), but operating on the <em>clades</em>
+ * themselves rather than on clade partitions.
+ *
+ * <p>
+ * The CCD0 expansion adds clade partitions {@code P -> {L, R}} that were never
+ * observed but whose parent {@code P} and children {@code L}, {@code R} all are.
+ * This class instead enumerates novel <em>clades</em> that a single
+ * nearest-neighbour-interchange (NNI) move can produce from the splits already
+ * stored in the CCD, without ever building a tree.
+ * </p>
+ *
+ * <p>
+ * <b>The move at the clade level.</b> An internal edge of a tree is a stored
+ * split {@code P -> {L, R}}: the parent clade {@code P} branches into children
+ * {@code L} and {@code R}. An NNI at that edge needs the grandchildren: pick a
+ * child to descend into, say {@code L -> {A, B}}, with sibling {@code R}. The
+ * two NNI moves recombine {@code {A, B, R}} so that the child of {@code P} is no
+ * longer {@code L = A ∪ B} but either {@code A ∪ R} or {@code B ∪ R}. Those
+ * unions are exactly the novel clades; each comes with the NNI-implied seed
+ * split into {@code {kept, sibling}} (e.g. {@code (A ∪ R) -> {A, R}}), whose two
+ * constituents are themselves existing clades. We read {@code A}, {@code B},
+ * {@code R} straight out of the split table.
+ * </p>
+ *
+ * <p>
+ * <b>Pairing modes.</b> The CCD graph mixes splits drawn from many posterior
+ * trees, so pairing a split {@code P -> {L, R}} with a grandchild split
+ * {@code L -> {A, B}} can combine splits that never co-occurred in one tree.
+ * The {@link PairingMode} controls which pairs are allowed:
+ * <ul>
+ * <li>{@link PairingMode#GRAPH_WIDE} pairs <em>any</em> stored split on
+ * {@code P} with <em>any</em> stored split on its child {@code L}. This is the
+ * cheapest, broadest reading; it generates clades that no single sampled tree is
+ * one NNI move away from.</li>
+ * <li>{@link PairingMode#CO_OCCURRING} only recombines grandchild splits that
+ * actually appeared together under {@code P} in some single base tree, i.e. the
+ * true NNI neighbourhood of the posterior sample. It walks the stored base trees
+ * and therefore requires the CCD to have been built with stored base trees
+ * (currently non-sampled-ancestor CCDs only).</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * The pass is read-only: it does not modify the CCD. Cost is proportional to the
+ * size of the CCD itself ({@code O(|splits| × d̄)}, with {@code d̄} the average
+ * number of splits per clade), not to the number of trees the CCD represents.
+ * </p>
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class NNICladeExpansion {
+
+    /** How splits may be paired to form NNI recombinations. */
+    public enum PairingMode {
+        /** Pair any stored split on P with any stored split on its child L. */
+        GRAPH_WIDE,
+        /** Only pair splits that co-occurred under P in some single base tree. */
+        CO_OCCURRING
+    }
+
+    /**
+     * One way a novel clade can be produced by an NNI move. The novel clade's
+     * taxa are {@code kept ∪ sibling}; its NNI-implied seed split is
+     * {@code {kept, sibling}}; it appears as a new child of {@code parent} in
+     * place of the original child {@code kept ∪ dropped}.
+     *
+     * @param parent  the parent clade P at the rearranged edge
+     * @param sibling the sibling clade R that joins the kept grandchild
+     * @param kept    the grandchild (A or B) that joins the sibling
+     * @param dropped the other grandchild, left behind under P
+     */
+    public record Provenance(Clade parent, Clade sibling, Clade kept, Clade dropped) {
+    }
+
+    /** A candidate clade not present in the CCD, with all the ways it arises. */
+    public static final class NovelClade {
+        /** Taxa of the novel clade (taxa-only bits). */
+        public final BitSet taxa;
+        /** Number of taxa in the novel clade. */
+        public final int size;
+        /** Every (parent, sibling, kept, dropped) that produces this clade. */
+        public final List<Provenance> provenances = new ArrayList<>(2);
+
+        private NovelClade(BitSet taxa) {
+            this.taxa = taxa;
+            this.size = taxa.cardinality();
+        }
+    }
+
+    private final AbstractCCD ccd;
+    private final PairingMode mode;
+
+    private final Map<BitSet, NovelClade> novelClades = new HashMap<>();
+    private long candidatesEmitted = 0;
+    private long candidatesAlreadyPresent = 0;
+    private boolean computed = false;
+
+    /** Taxa-only bits of every clade in the CCD, for fast presence tests. */
+    private Set<BitSet> existingTaxa;
+
+    /**
+     * @param ccd  the CCD whose clade set is expanded (not modified)
+     * @param mode how splits may be paired into NNI recombinations
+     */
+    public NNICladeExpansion(AbstractCCD ccd, PairingMode mode) {
+        this.ccd = ccd;
+        this.mode = mode;
+    }
+
+    /** Runs the expansion if not already done; idempotent. */
+    public NNICladeExpansion compute() {
+        if (computed) {
+            return this;
+        }
+
+        existingTaxa = new HashSet<>(ccd.getNumberOfClades() * 2);
+        for (Clade clade : ccd.getClades()) {
+            existingTaxa.add(clade.getCladeInBitsTaxaOnly());
+        }
+
+        switch (mode) {
+            case GRAPH_WIDE -> expandGraphWide();
+            case CO_OCCURRING -> expandCoOccurring();
+        }
+
+        computed = true;
+        return this;
+    }
+
+    /* -- GRAPH-WIDE EXPANSION (pair any stored adjacent splits) -- */
+
+    private void expandGraphWide() {
+        for (Clade parent : ccd.getClades()) {
+            // need at least 3 taxa to have a (cherry-or-larger child) + sibling
+            if (parent.size() < 3) {
+                continue;
+            }
+            for (CladePartition split : parent.getPartitions()) {
+                Clade childA = split.getChildClades()[0];
+                Clade childB = split.getChildClades()[1];
+                // descend into each child, with the other child as the sibling
+                recombineAllGrandchildSplits(parent, childA, childB);
+                recombineAllGrandchildSplits(parent, childB, childA);
+            }
+        }
+    }
+
+    /* For parent P, descend-into child L and sibling R; recombine every L-split. */
+    private void recombineAllGrandchildSplits(Clade parent, Clade descend, Clade sibling) {
+        for (CladePartition grandSplit : descend.getPartitions()) {
+            Clade a = grandSplit.getChildClades()[0];
+            Clade b = grandSplit.getChildClades()[1];
+            emit(parent, sibling, a, b); // novel = A ∪ R, drop B
+            emit(parent, sibling, b, a); // novel = B ∪ R, drop A
+        }
+    }
+
+    /* -- CO-OCCURRING EXPANSION (only splits seen together in one base tree) -- */
+
+    private void expandCoOccurring() {
+        List<Tree> baseTrees = ccd.getBaseTrees();
+        if (baseTrees == null) {
+            throw new IllegalStateException(
+                    "CO_OCCURRING pairing needs all base trees stored; "
+                            + "build the CCD with storeBaseTrees = true.");
+        }
+        for (Tree tree : baseTrees) {
+            Map<Node, Clade> nodeToClade = new HashMap<>();
+            mapNodesToClades(tree.getRoot(), nodeToClade);
+            recombineTree(tree.getRoot(), nodeToClade);
+        }
+    }
+
+    /* Map every node of a base tree to its CCD clade via taxa bits. */
+    private BitSet mapNodesToClades(Node vertex, Map<Node, Clade> map) {
+        BitSet bits = BitSet.newBitSet(ccd.getSizeOfLeavesArray());
+        if (vertex.isLeaf()) {
+            bits.set(vertex.getNr());
+        } else {
+            for (Node child : vertex.getChildren()) {
+                bits.or(mapNodesToClades(child, map));
+            }
+        }
+        Clade clade = ccd.getClade(bits);
+        if (clade == null) {
+            throw new UnsupportedOperationException(
+                    "No clade found for a base-tree node; CO_OCCURRING pairing "
+                            + "currently supports non-sampled-ancestor CCDs only.");
+        }
+        map.put(vertex, clade);
+        return bits;
+    }
+
+    /* Walk internal edges of one base tree, emitting their NNI recombinations. */
+    private void recombineTree(Node vertex, Map<Node, Clade> map) {
+        if (vertex.isLeaf()) {
+            return;
+        }
+        List<Node> children = vertex.getChildren();
+        if (children.size() == 2) {
+            Node left = children.get(0);
+            Node right = children.get(1);
+            Clade parent = map.get(vertex);
+            // edge above an internal child = NNI site; the other child is the sibling
+            if (!left.isLeaf()) {
+                recombineAt(parent, left, right, map);
+            }
+            if (!right.isLeaf()) {
+                recombineAt(parent, right, left, map);
+            }
+        }
+        for (Node child : children) {
+            recombineTree(child, map);
+        }
+    }
+
+    /* The two NNI moves at the edge (parent, descend), with given sibling. */
+    private void recombineAt(Clade parent, Node descend, Node siblingNode, Map<Node, Clade> map) {
+        if (descend.getChildren().size() != 2) {
+            return;
+        }
+        Clade sibling = map.get(siblingNode);
+        Clade a = map.get(descend.getChildren().get(0));
+        Clade b = map.get(descend.getChildren().get(1));
+        emit(parent, sibling, a, b);
+        emit(parent, sibling, b, a);
+    }
+
+    /* -- SHARED EMIT -- */
+
+    /* Record the candidate clade kept ∪ sibling; novel iff not already in C. */
+    private void emit(Clade parent, Clade sibling, Clade kept, Clade dropped) {
+        BitSet taxa = (BitSet) kept.getCladeInBitsTaxaOnly().clone();
+        taxa.or(sibling.getCladeInBitsTaxaOnly());
+
+        candidatesEmitted++;
+        if (existingTaxa.contains(taxa)) {
+            candidatesAlreadyPresent++;
+            return;
+        }
+        NovelClade novel = novelClades.computeIfAbsent(taxa, NovelClade::new);
+        novel.provenances.add(new Provenance(parent, sibling, kept, dropped));
+    }
+
+    /* -- RESULTS -- */
+
+    /** @return the distinct novel candidate clades (not present in the CCD) */
+    public Collection<NovelClade> getNovelClades() {
+        compute();
+        return novelClades.values();
+    }
+
+    /** @return number of distinct novel clades found */
+    public int getNumberOfNovelClades() {
+        compute();
+        return novelClades.size();
+    }
+
+    /** @return total candidate emissions, counting multiplicity */
+    public long getNumberOfCandidatesEmitted() {
+        compute();
+        return candidatesEmitted;
+    }
+
+    /** @return emissions whose taxa already form a clade in the CCD */
+    public long getNumberOfCandidatesAlreadyPresent() {
+        compute();
+        return candidatesAlreadyPresent;
+    }
+
+    /**
+     * Number of tree topologies the CCD would gain if this NNI expansion were
+     * applied. Computed without mutating the CCD.
+     *
+     * <p>
+     * Equivalent to running {@link ccd.algorithms.regularisation.NNICladeExpander}
+     * and then asking the resulting CCD for {@link AbstractCCD#getNumberOfTrees()}
+     * minus the pre-expansion count, but skipping the graph mutation. The
+     * read-only enumeration must still run (via {@link #compute()}); the saving
+     * is in the mutation step itself.
+     * </p>
+     *
+     * @return T_after - T_before, the count of new trees the expansion adds
+     */
+    public BigInteger getNumberOfNovelTrees() {
+        return getNumberOfTreesAfterExpansion().subtract(ccd.getNumberOfTrees());
+    }
+
+    /**
+     * Number of tree topologies the CCD would contain after this NNI expansion
+     * were applied, computed without mutating the CCD.
+     *
+     * <p>
+     * The expansion only ever (a) adds partitions {@code P -> {K, B}} on
+     * existing parents {@code P}, with {@code K} a novel clade and {@code B}
+     * existing; and (b) gives each novel {@code K} seed splits {@code K ->
+     * {kept, sibling}} whose children are both existing. So the dependency
+     * graph is still a DAG and a single size-ordered pass settles all
+     * topology counts.
+     * </p>
+     *
+     * @return the post-expansion topology count at the root clade
+     */
+    public BigInteger getNumberOfTreesAfterExpansion() {
+        compute();
+
+        // (existing parent P) -> (novel K -> set of distinct dropped clades B);
+        // mirrors NNICladeExpander's per-partition de-duplication
+        Map<Clade, Map<NovelClade, Set<Clade>>> novelChildrenByParent = new HashMap<>();
+        // (novel K) -> set of distinct unordered {kept, sibling} seed splits
+        Map<NovelClade, Set<Set<Clade>>> seedSplitsByNovel = new HashMap<>();
+
+        for (NovelClade k : novelClades.values()) {
+            for (Provenance prov : k.provenances) {
+                Set<Clade> seed = new HashSet<>(2);
+                seed.add(prov.kept());
+                seed.add(prov.sibling());
+                seedSplitsByNovel.computeIfAbsent(k, x -> new HashSet<>()).add(seed);
+
+                novelChildrenByParent
+                        .computeIfAbsent(prov.parent(), p -> new HashMap<>())
+                        .computeIfAbsent(k, x -> new HashSet<>())
+                        .add(prov.dropped());
+            }
+        }
+
+        // T_new(c) for every existing clade c, and T_new(K) for every novel K.
+        // We recompute the topology product over the *existing* partitions of c
+        // using updated child counts - we cannot reuse c.getNumberOfTopologies()
+        // here, because a novel partition deeper in the tree can change the
+        // count of an existing child of c.
+        Map<Clade, BigInteger> tExisting = new HashMap<>(ccd.getNumberOfClades() * 2);
+        Map<NovelClade, BigInteger> tNovel = new HashMap<>(novelClades.size() * 2);
+
+        List<Clade> existingBySize = new ArrayList<>(ccd.getClades());
+        existingBySize.sort(Comparator.comparingInt(Clade::size));
+        List<NovelClade> novelBySize = new ArrayList<>(novelClades.values());
+        novelBySize.sort(Comparator.comparingInt(n -> n.size));
+
+        // merged size-ascending walk; within a size no novel/existing pair
+        // depends on the other, so equal-size ordering is arbitrary
+        int ei = 0;
+        int ni = 0;
+        while (ei < existingBySize.size() || ni < novelBySize.size()) {
+            int eSize = (ei < existingBySize.size())
+                    ? existingBySize.get(ei).size() : Integer.MAX_VALUE;
+            int nSize = (ni < novelBySize.size())
+                    ? novelBySize.get(ni).size : Integer.MAX_VALUE;
+            if (nSize <= eSize) {
+                NovelClade k = novelBySize.get(ni++);
+                BigInteger t = BigInteger.ZERO;
+                for (Set<Clade> seed : seedSplitsByNovel.get(k)) {
+                    Iterator<Clade> it = seed.iterator();
+                    Clade a = it.next();
+                    Clade b = it.next();
+                    t = t.add(tExisting.get(a).multiply(tExisting.get(b)));
+                }
+                tNovel.put(k, t);
+            } else {
+                Clade c = existingBySize.get(ei++);
+                BigInteger t;
+                if (c.isLeaf()) {
+                    t = BigInteger.ONE;
+                } else {
+                    t = BigInteger.ZERO;
+                    for (CladePartition p : c.getPartitions()) {
+                        BigInteger left = tExisting.get(p.getChildClades()[0]);
+                        BigInteger right = tExisting.get(p.getChildClades()[1]);
+                        t = t.add(left.multiply(right));
+                    }
+                }
+                Map<NovelClade, Set<Clade>> kids = novelChildrenByParent.get(c);
+                if (kids != null) {
+                    for (Map.Entry<NovelClade, Set<Clade>> e : kids.entrySet()) {
+                        BigInteger tK = tNovel.get(e.getKey());
+                        for (Clade dropped : e.getValue()) {
+                            t = t.add(tK.multiply(tExisting.get(dropped)));
+                        }
+                    }
+                }
+                tExisting.put(c, t);
+            }
+        }
+
+        return tExisting.get(ccd.getRootClade());
+    }
+
+    /**
+     * Number of tree topologies the CCD would contain after this NNI clade
+     * expansion <em>and</em> a subsequent {@link
+     * ccd.algorithms.regularisation.CCDExpansion} pass (i.e. the
+     * {@link ccd.model.NNIRegCCD} pipeline graph), computed without mutating
+     * the CCD.
+     *
+     * <p>
+     * After both passes every clade {@code P} (observed or NNI-novel) carries
+     * every compatible split {@code (L, R)} - {@code L ∪ R = P},
+     * {@code L ∩ R = ∅}, both {@code L} and {@code R} clades in the universe.
+     * So we enumerate compatible splits directly over the union of existing
+     * and novel taxa-sets.
+     * </p>
+     *
+     * @return the post-(NNI + split-expansion) topology count at the root
+     */
+    public BigInteger getNumberOfTreesAfterFullExpansion() {
+        compute();
+
+        // universe (existing + novel), bucketed by clade size for the split scan
+        Map<Integer, List<BitSet>> bySize = new HashMap<>();
+        int maxSize = 0;
+        for (Clade c : ccd.getClades()) {
+            bySize.computeIfAbsent(c.size(), k -> new ArrayList<>())
+                    .add(c.getCladeInBitsTaxaOnly());
+            if (c.size() > maxSize) maxSize = c.size();
+        }
+        for (NovelClade nk : novelClades.values()) {
+            bySize.computeIfAbsent(nk.size, k -> new ArrayList<>()).add(nk.taxa);
+            if (nk.size > maxSize) maxSize = nk.size;
+        }
+
+        Map<BitSet, BigInteger> tMap = new HashMap<>(
+                (ccd.getNumberOfClades() + novelClades.size()) * 2);
+
+        for (int size = 1; size <= maxSize; size++) {
+            List<BitSet> here = bySize.get(size);
+            if (here == null) continue;
+            for (BitSet pBits : here) {
+                if (size == 1) {
+                    tMap.put(pBits, BigInteger.ONE);
+                    continue;
+                }
+                BigInteger t = BigInteger.ZERO;
+                int halfSize = size / 2;
+                for (int j = 1; j <= halfSize; j++) {
+                    List<BitSet> bucket = bySize.get(j);
+                    if (bucket == null) continue;
+                    int complementSize = size - j;
+                    for (BitSet lBits : bucket) {
+                        if (!pBits.contains(lBits)) continue;
+                        BitSet rBits = (BitSet) pBits.clone();
+                        rBits.andNot(lBits);
+                        BigInteger tR = tMap.get(rBits);
+                        if (tR == null) continue;
+                        if (j < complementSize) {
+                            t = t.add(tMap.get(lBits).multiply(tR));
+                        } else if (lBits.nextSetBit(0) < rBits.nextSetBit(0)) {
+                            // even split: L and R both appear in this bucket -
+                            // use first-bit ordering to count each unordered
+                            // partition exactly once
+                            t = t.add(tMap.get(lBits).multiply(tR));
+                        }
+                    }
+                }
+                tMap.put(pBits, t);
+            }
+        }
+
+        return tMap.get(ccd.getRootClade().getCladeInBitsTaxaOnly());
+    }
+
+    /**
+     * @return T_full - T_before, the number of trees that the full
+     *         NNI + split expansion pipeline adds on top of the input CCD
+     */
+    public BigInteger getNumberOfNovelTreesAfterFullExpansion() {
+        return getNumberOfTreesAfterFullExpansion().subtract(ccd.getNumberOfTrees());
+    }
+
+    /**
+     * Total probability mass that the {@link ccd.model.NNIRegCCD} pipeline
+     * (NNI clade expansion + {@link ccd.algorithms.regularisation.CCDExpansion}
+     * + additive-{@code alpha} regularisation) would assign to trees containing
+     * at least one novel clade. Computed without mutating the CCD.
+     *
+     * <p>
+     * Equivalent to {@code getProbabilityOfNNIExpandedTrees(alpha, alpha)}
+     * (single-level {@code AdditiveX} smoothing, matching {@code
+     * regulariseRegCCD(alpha)}).
+     * </p>
+     *
+     * @param alpha additive-smoothing pseudocount used on every partition
+     * @return P(tree contains a novel clade) under the post-pipeline distribution
+     */
+    public double getProbabilityOfNNIExpandedTrees(double alpha) {
+        return getProbabilityOfNNIExpandedTrees(alpha, alpha);
+    }
+
+    /**
+     * Two-level additive smoothing variant: existing-and-split-expanded
+     * partitions get pseudocount {@code alpha}; partitions touching a novel
+     * clade get pseudocount {@code beta} (matching {@code
+     * CCDRegularisationStrategy.AdditiveXY}).
+     *
+     * <p>
+     * Probability is computed via {@code 1 - M(root)}, where {@code M(c)} is
+     * the post-regularisation total CCP-product mass on trees rooted at
+     * {@code c} that use only existing clades. {@code M} obeys
+     * {@code M(leaf) = 1}, {@code M(novel) = 0}, and for existing {@code c}
+     * with at least 2 partitions in the full graph:
+     * {@code M(c) = Σ_p CCP(p) · M(L) · M(R)} over the existing-only
+     * partitions {@code p = (L, R)}, with CCPs read off the post-regularisation
+     * formula. Single-partition clades retain {@code CCP = 1} (the regulariser
+     * skips them).
+     * </p>
+     *
+     * @param alpha pseudocount for existing/split-expanded partitions
+     * @param beta  pseudocount for NNI-derived (novel-touching) partitions
+     * @return P(tree contains a novel clade) under the post-pipeline distribution
+     */
+    public double getProbabilityOfNNIExpandedTrees(double alpha, double beta) {
+        compute();
+
+        // universe (existing + novel) for the compatible-split count
+        Map<Integer, List<BitSet>> bySize = new HashMap<>();
+        Set<BitSet> universe = new HashSet<>();
+        for (Clade c : ccd.getClades()) {
+            BitSet bits = c.getCladeInBitsTaxaOnly();
+            bySize.computeIfAbsent(c.size(), k -> new ArrayList<>()).add(bits);
+            universe.add(bits);
+        }
+        for (NovelClade nk : novelClades.values()) {
+            bySize.computeIfAbsent(nk.size, k -> new ArrayList<>()).add(nk.taxa);
+            universe.add(nk.taxa);
+        }
+
+        // M(c) bottom-up over existing clades (novel clades have M = 0)
+        Map<Clade, Double> mExisting = new HashMap<>(ccd.getNumberOfClades() * 2);
+        List<Clade> existingBySize = new ArrayList<>(ccd.getClades());
+        existingBySize.sort(Comparator.comparingInt(Clade::size));
+
+        for (Clade c : existingBySize) {
+            if (c.isLeaf()) {
+                mExisting.put(c, 1.0);
+                continue;
+            }
+            int nExisting = c.getNumberOfPartitions();
+            int nTotal = countCompatibleSplits(c.getCladeInBitsTaxaOnly(),
+                    c.size(), bySize, universe);
+            int nNNI = nTotal - nExisting;
+
+            double m = 0.0;
+            if (nTotal <= 1 || c.isCherry()) {
+                // regulariser skips: CCP of the single partition is 1
+                CladePartition only = c.getPartitions().get(0);
+                m = mExisting.get(only.getChildClades()[0])
+                        * mExisting.get(only.getChildClades()[1]);
+            } else {
+                double denom = c.getNumberOfOccurrences()
+                        + nExisting * alpha + nNNI * beta;
+                for (CladePartition p : c.getPartitions()) {
+                    double ccp = (p.getNumberOfOccurrences() + alpha) / denom;
+                    Clade l = p.getChildClades()[0];
+                    Clade r = p.getChildClades()[1];
+                    m += ccp * mExisting.get(l) * mExisting.get(r);
+                }
+            }
+            mExisting.put(c, m);
+        }
+
+        return 1.0 - mExisting.get(ccd.getRootClade());
+    }
+
+    private static int countCompatibleSplits(BitSet pBits, int pSize,
+            Map<Integer, List<BitSet>> bySize, Set<BitSet> universe) {
+        int count = 0;
+        int halfSize = pSize / 2;
+        for (int j = 1; j <= halfSize; j++) {
+            List<BitSet> bucket = bySize.get(j);
+            if (bucket == null) continue;
+            int complementSize = pSize - j;
+            for (BitSet lBits : bucket) {
+                if (!pBits.contains(lBits)) continue;
+                BitSet rBits = (BitSet) pBits.clone();
+                rBits.andNot(lBits);
+                if (!universe.contains(rBits)) continue;
+                if (j < complementSize) {
+                    count++;
+                } else if (lBits.nextSetBit(0) < rBits.nextSetBit(0)) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    /** Where a held-out tree sits relative to this CCD's NNI universe. */
+    public enum TreeZone {
+        /** Every internal clade of the tree is observed in the input CCD. */
+        OBSERVED,
+        /** All internal clades are in the universe (existing ∪ NNI-novel),
+         *  and at least one is NNI-novel. */
+        NNI_EXPANDED,
+        /** At least one internal clade is outside the universe; even the
+         *  NNI-expanded graph cannot give this tree positive probability. */
+        OUT_OF_UNIVERSE
+    }
+
+    /** Counts of held-out trees in each zone. */
+    public record ZoneCounts(int observed, int nniExpanded, int outOfUniverse) {
+        public int total() {
+            return observed + nniExpanded + outOfUniverse;
+        }
+    }
+
+    /**
+     * Classify each held-out tree by whether it sits inside the input CCD's
+     * observed-clade set, only inside the NNI-expanded universe, or contains a
+     * clade outside the universe altogether.
+     *
+     * <p>
+     * Assumes the held-out trees use the same leaf indexing as the CCD
+     * (consistent BEAST translate blocks across independent runs of the same
+     * analysis - the usual case).
+     * </p>
+     *
+     * @param trees independent trees to classify against this NNI universe
+     * @return counts of trees in each {@link TreeZone}
+     */
+    public ZoneCounts classifyTrees(Iterable<Tree> trees) {
+        compute();
+        Set<BitSet> novelTaxa = new HashSet<>(novelClades.size() * 2);
+        for (NovelClade nk : novelClades.values()) {
+            novelTaxa.add(nk.taxa);
+        }
+
+        int observed = 0;
+        int nniExpanded = 0;
+        int outOfUniverse = 0;
+        int leafArraySize = ccd.getSizeOfLeavesArray();
+
+        for (Tree tree : trees) {
+            List<BitSet> internals = new ArrayList<>(tree.getNodeCount() / 2);
+            collectInternalBits(tree.getRoot(), leafArraySize, internals);
+            boolean anyNovel = false;
+            boolean anyOut = false;
+            for (BitSet bits : internals) {
+                if (existingTaxa.contains(bits)) continue;
+                if (novelTaxa.contains(bits)) {
+                    anyNovel = true;
+                    continue;
+                }
+                anyOut = true;
+                break;
+            }
+            if (anyOut) outOfUniverse++;
+            else if (anyNovel) nniExpanded++;
+            else observed++;
+        }
+        return new ZoneCounts(observed, nniExpanded, outOfUniverse);
+    }
+
+    private static BitSet collectInternalBits(Node v, int size, List<BitSet> internals) {
+        BitSet bits = BitSet.newBitSet(size);
+        if (v.isLeaf()) {
+            bits.set(v.getNr());
+        } else {
+            for (Node c : v.getChildren()) {
+                bits.or(collectInternalBits(c, size, internals));
+            }
+            internals.add(bits);
+        }
+        return bits;
+    }
+
+    /** @return novel clades found per size; index i holds the count of size i */
+    public int[] novelSizeHistogram() {
+        compute();
+        int[] hist = new int[ccd.getSizeOfLeavesArray() + 1];
+        for (NovelClade novel : novelClades.values()) {
+            hist[novel.size]++;
+        }
+        return hist;
+    }
+
+    /* -- REPORTING -- */
+
+    /** @return a human-readable summary of this single expansion */
+    public String report() {
+        compute();
+        int numClades = ccd.getNumberOfClades();
+        int numNovel = novelClades.size();
+        double blowup = (numClades == 0) ? 0 : (numNovel / (double) numClades);
+        double presentFrac = (candidatesEmitted == 0) ? 0
+                : (candidatesAlreadyPresent / (double) candidatesEmitted);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("NNI clade expansion [").append(mode).append("]\n");
+        sb.append(String.format("  taxa                 : %d%n", ccd.getNumberOfLeaves()));
+        sb.append(String.format("  base trees           : %d%n", ccd.getNumberOfBaseTrees()));
+        sb.append(String.format("  clades in C          : %d%n", numClades));
+        sb.append(String.format("  candidates emitted   : %d%n", candidatesEmitted));
+        sb.append(String.format("  already in C         : %d (%.1f%%)%n",
+                candidatesAlreadyPresent, 100 * presentFrac));
+        sb.append(String.format("  novel clades         : %d%n", numNovel));
+        sb.append(String.format("  blow-up (novel/|C|)  : %.3f%n", blowup));
+        BigInteger treesBefore = ccd.getNumberOfTrees();
+        BigInteger treesAfterNNI = getNumberOfTreesAfterExpansion();
+        BigInteger treesAfterFull = getNumberOfTreesAfterFullExpansion();
+        sb.append(String.format("  trees in C           : %s%n", treesBefore));
+        sb.append(String.format("  trees after NNI      : %s%n", treesAfterNNI));
+        sb.append(String.format("  trees after NNI+split: %s%n", treesAfterFull));
+        sb.append(String.format("  novel trees (NNI)    : %s%n", treesAfterNNI.subtract(treesBefore)));
+        sb.append(String.format("  novel trees (full)   : %s%n", treesAfterFull.subtract(treesBefore)));
+        // P(NNI-expanded tree) varies with both α and β under AdditiveXY;
+        // show a small grid covering the single-level default and a typical
+        // fitted two-level setting where β << α dampens speculative mass
+        sb.append("  P(novel tree) at (α, β):\n");
+        sb.append(String.format("    (0.4 , 0.4 )  single-level default : %.6f%n",
+                getProbabilityOfNNIExpandedTrees(0.4, 0.4)));
+        sb.append(String.format("    (0.4 , 0.04)  β 10× damped         : %.6f%n",
+                getProbabilityOfNNIExpandedTrees(0.4, 0.04)));
+        sb.append(String.format("    (0.2 , 0.02)  recalled fit         : %.6f%n",
+                getProbabilityOfNNIExpandedTrees(0.2, 0.02)));
+        sb.append(String.format("    (0.265, 0.0014) GW held-out fit    : %.6f%n",
+                getProbabilityOfNNIExpandedTrees(0.265, 0.0014)));
+        sb.append(String.format("    (0.260, 0.0084) CO held-out fit    : %.6f%n",
+                getProbabilityOfNNIExpandedTrees(0.260, 0.0084)));
+        sb.append("  novel by size        :");
+        int[] hist = novelSizeHistogram();
+        for (int s = 2; s < hist.length; s++) {
+            if (hist[s] > 0) {
+                sb.append(' ').append(s).append(':').append(hist[s]);
+            }
+        }
+        sb.append('\n');
+        return sb.toString();
+    }
+
+    /**
+     * Runs both pairing modes on the given CCD and reports each, plus how the
+     * graph-wide novel set relates to the strict co-occurring one.
+     *
+     * @param ccd CCD to analyse (must have base trees stored for the strict mode)
+     * @return a combined report
+     */
+    public static String compareModes(AbstractCCD ccd) {
+        return compareModes(ccd, null);
+    }
+
+    /**
+     * As {@link #compareModes(AbstractCCD)}, plus a held-out classification
+     * section reporting the fraction of {@code heldOut} trees that fall inside
+     * the observed-clade zone, the NNI-expanded zone, or outside the universe
+     * altogether - in each pairing mode.
+     *
+     * @param ccd     CCD to analyse (training)
+     * @param heldOut independent trees to score against the NNI universe;
+     *                if {@code null} or empty, no classification section is added
+     * @return combined report
+     */
+    public static String compareModes(AbstractCCD ccd, List<Tree> heldOut) {
+        NNICladeExpansion broad = new NNICladeExpansion(ccd, PairingMode.GRAPH_WIDE).compute();
+        StringBuilder sb = new StringBuilder();
+        sb.append(broad.report());
+
+        NNICladeExpansion strict = null;
+        if (ccd.getBaseTrees() == null) {
+            sb.append("NNI clade expansion [CO_OCCURRING]: skipped (base trees not stored)\n");
+        } else {
+            strict = new NNICladeExpansion(ccd, PairingMode.CO_OCCURRING).compute();
+            sb.append(strict.report());
+        }
+
+        if (heldOut != null && !heldOut.isEmpty()) {
+            sb.append(heldOutClassification(broad, strict, heldOut));
+        }
+
+        if (strict == null) {
+            return sb.toString();
+        }
+
+        Set<BitSet> broadSet = broad.novelClades.keySet();
+        Set<BitSet> strictSet = strict.novelClades.keySet();
+        int onlyBroad = 0;
+        for (BitSet b : broadSet) {
+            if (!strictSet.contains(b)) {
+                onlyBroad++;
+            }
+        }
+        int onlyStrict = 0;
+        for (BitSet b : strictSet) {
+            if (!broadSet.contains(b)) {
+                onlyStrict++;
+            }
+        }
+        sb.append("comparison\n");
+        sb.append(String.format("  shared novel clades  : %d%n", strictSet.size() - onlyStrict));
+        sb.append(String.format("  graph-wide only      : %d%n", onlyBroad));
+        sb.append(String.format("  co-occurring only    : %d%n", onlyStrict));
+        return sb.toString();
+    }
+
+    /* Format the held-out classification block for one or both pairing modes. */
+    private static String heldOutClassification(NNICladeExpansion broad,
+                                                NNICladeExpansion strict,
+                                                List<Tree> heldOut) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("held-out classification (%d trees)%n", heldOut.size()));
+        appendZoneLine(sb, "GRAPH_WIDE", broad.classifyTrees(heldOut));
+        if (strict != null) {
+            appendZoneLine(sb, "CO_OCCURRING", strict.classifyTrees(heldOut));
+        }
+        return sb.toString();
+    }
+
+    private static void appendZoneLine(StringBuilder sb, String label, ZoneCounts c) {
+        int total = c.total();
+        double pct = total == 0 ? 0 : 100.0 / total;
+        sb.append(String.format("  [%s] observed: %d (%.2f%%)  NNI-expanded: %d (%.2f%%)  out-of-universe: %d (%.2f%%)%n",
+                label,
+                c.observed(), c.observed() * pct,
+                c.nniExpanded(), c.nniExpanded() * pct,
+                c.outOfUniverse(), c.outOfUniverse() * pct));
+    }
+
+    /**
+     * CLI: report NNI clade-expansion properties of a tree file, optionally with
+     * a held-out tree file classified by zone (observed / NNI-expanded /
+     * out-of-universe).
+     * <p>
+     * Usage: {@code NNICladeExpansion <trees-file> [burnin-percentage] [held-out-trees-file]}
+     *
+     * @param args trees file path, optional burn-in percentage (default 10),
+     *             and optional held-out trees file
+     * @throws Exception if a tree file cannot be read
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.err.println("Usage: NNICladeExpansion <trees-file> [burnin-percentage] [held-out-trees-file]");
+            System.exit(1);
+        }
+        int burnin = (args.length >= 2) ? Integer.parseInt(args[1]) : 10;
+        TreeAnnotator.MemoryFriendlyTreeSet treeSet = CCDToolUtil.getTreeSet(args[0], burnin);
+        CCD0 ccd = new CCD0(treeSet, true);
+
+        List<Tree> heldOut = null;
+        if (args.length >= 3) {
+            TreeAnnotator.MemoryFriendlyTreeSet heldOutSet = CCDToolUtil.getTreeSet(args[2], burnin);
+            heldOut = new ArrayList<>();
+            heldOutSet.reset();
+            while (heldOutSet.hasNext()) {
+                heldOut.add(heldOutSet.next());
+            }
+        }
+
+        System.out.print(compareModes(ccd, heldOut));
+    }
+}

--- a/src/main/java/ccd/algorithms/TreeDistances.java
+++ b/src/main/java/ccd/algorithms/TreeDistances.java
@@ -1,12 +1,11 @@
 package ccd.algorithms;
 
+import beast.base.evolution.tree.Node;
 import ccd.model.WrappedBeastTree;
+import ccd.model.WrappedBeastTreeWithSampledAncestor;
 import ccd.model.bitsets.BitSet;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.PriorityQueue;
+import java.util.*;
 
 /**
  * This class provides distance computation methods for two beast trees.
@@ -25,10 +24,157 @@ public class TreeDistances {
      * @return the RF distance (divided by 2) for the two given trees
      */
     public static int robinsonsFouldDistance(WrappedBeastTree first, WrappedBeastTree second) {
+        // if input trees are of type WrappedBeastTreeWithSampledAncestor,
+        // clades with the same taxa but different SA info would be identified as different clades,
+        // therefore increase the distance
         ArrayList<BitSet> firstClades = first.getNontrivialClades();
         ArrayList<BitSet> secondClades = second.getNontrivialClades();
         firstClades.removeAll(secondClades);
         return firstClades.size();
+    }
+
+    /**
+     * Symmetric difference of the two trees' sampled-ancestor leaf sets:
+     * {@code |SA(first) △ SA(second)|}. This counts only SA-status
+     * disagreements per leaf and ignores topology entirely; two trees with
+     * completely different topologies but identical SA sets get distance 0.
+     *
+     * <p>This is <em>not</em> the sampled-ancestor Robinson-Foulds distance;
+     * it is one of its two components (the asymmetric singleton penalty).
+     * For the full SA-RF metric that combines topology and SA-status
+     * differences, see
+     * {@link #sampledAncestorRobinsonFoulds(WrappedBeastTreeWithSampledAncestor, WrappedBeastTreeWithSampledAncestor)}.
+     */
+    public static int sampledAncestorSymmetricDistance(WrappedBeastTreeWithSampledAncestor first, WrappedBeastTreeWithSampledAncestor second) {
+        ArrayList<Node> firstTreeSANodes = new ArrayList<>(first.getSampledAncestors());
+        ArrayList<Node> secondTreeSANodes = new ArrayList<>(second.getSampledAncestors());
+
+        ArrayList<Node> onlyFirst = new ArrayList<>(firstTreeSANodes);
+        onlyFirst.removeAll(secondTreeSANodes);
+
+        ArrayList<Node> onlySecond = new ArrayList<>(secondTreeSANodes);
+        onlySecond.removeAll(firstTreeSANodes);
+
+        return onlyFirst.size() + onlySecond.size();
+    }
+
+    /**
+     * Sampled-ancestor Robinson-Foulds distance between two SA trees on the
+     * same taxa. The "cuttable" clade set of a tree {@code T = (tau, sigma)}
+     * is
+     * <pre>
+     *   C_cut(T) = { C(v) : v internal in tau } u { {i} : sigma_i = 0 }
+     * </pre>
+     * the taxa-only internal-node clades, plus singleton clades for the
+     * non-SA leaves only (an SA leaf has a zero-length parent branch and
+     * cannot be separated from its parent's clade by an edge cut, so no
+     * {@code {i}} singleton is contributed). The distance is the size of
+     * the symmetric difference,
+     * <pre>
+     *   d_SA-RF(T, T') = |C_cut(T) △ C_cut(T')|.
+     * </pre>
+     *
+     * <p>Properties:
+     * <ul>
+     *   <li>Reduces to standard rooted RF (full symmetric difference) when
+     *       neither tree contains SAs.
+     *   <li>Asymmetric singleton penalty: leaf {@code i} being SA in only
+     *       one tree contributes 1 (not 2) to the distance, since the SA
+     *       tree contributes no {@code {i}} clade.
+     *   <li>Symmetric and non-negative; zero iff the two trees have the
+     *       same internal clades and the same SA pattern.
+     * </ul>
+     *
+     * <p>This method returns the full symmetric-difference cardinality,
+     * unlike {@link #robinsonsFouldDistance(WrappedBeastTree, WrappedBeastTree)}
+     * which returns the halved count and relies on the binary-tree symmetry
+     * {@code |T \\ T'| = |T' \\ T|} that the asymmetric singleton penalty
+     * here breaks.
+     */
+    public static int sampledAncestorRobinsonFoulds(WrappedBeastTreeWithSampledAncestor first,
+                                                    WrappedBeastTreeWithSampledAncestor second) {
+        int n = first.getWrappedTree().getLeafNodeCount();
+        if (second.getWrappedTree().getLeafNodeCount() != n) {
+            throw new IllegalArgumentException(
+                    "SA-RF requires both trees to have the same number of taxa; got "
+                            + n + " and " + second.getWrappedTree().getLeafNodeCount());
+        }
+
+        Set<BitSet> cuttableFirst = cuttableCladeSet(first, n);
+        Set<BitSet> cuttableSecond = cuttableCladeSet(second, n);
+
+        int onlyFirst = 0;
+        for (BitSet c : cuttableFirst) if (!cuttableSecond.contains(c)) onlyFirst++;
+        int onlySecond = 0;
+        for (BitSet c : cuttableSecond) if (!cuttableFirst.contains(c)) onlySecond++;
+
+        return onlyFirst + onlySecond;
+    }
+
+    /**
+     * Pure topology Robinson-Foulds distance on SA trees: counts internal-node
+     * clades (taxa-only, ignoring SA flags) that appear in {@code first} but
+     * not {@code second}.
+     *
+     * <p>Useful as a complement to
+     * {@link #robinsonsFouldDistance(WrappedBeastTree, WrappedBeastTree)} when
+     * called on {@link WrappedBeastTreeWithSampledAncestor} instances: that
+     * method uses the wide bitsets ({@code [0,n)} taxa, {@code [n,2n)} SA
+     * flags) so two trees with the same taxa-only clades but different
+     * direct-SA-leaf-children patterns at a clade are counted as differing.
+     * This method strips the SA flags and considers only base topology.
+     *
+     * <p>Follows the halved convention of
+     * {@link #robinsonsFouldDistance(WrappedBeastTree, WrappedBeastTree)}: for
+     * binary trees on the same taxa,
+     * {@code |topology(T1) \\ topology(T2)| = |topology(T2) \\ topology(T1)|},
+     * so this is half the symmetric difference.
+     */
+    public static int topologyRobinsonFoulds(WrappedBeastTreeWithSampledAncestor first,
+                                             WrappedBeastTreeWithSampledAncestor second) {
+        int n = first.getWrappedTree().getLeafNodeCount();
+        if (second.getWrappedTree().getLeafNodeCount() != n) {
+            throw new IllegalArgumentException(
+                    "topologyRF requires both trees to have the same number of taxa; got "
+                            + n + " and " + second.getWrappedTree().getLeafNodeCount());
+        }
+        Set<BitSet> firstClades = internalCladesTaxaOnly(first, n);
+        Set<BitSet> secondClades = internalCladesTaxaOnly(second, n);
+        int onlyFirst = 0;
+        for (BitSet c : firstClades) if (!secondClades.contains(c)) onlyFirst++;
+        return onlyFirst;
+    }
+
+    private static Set<BitSet> cuttableCladeSet(WrappedBeastTreeWithSampledAncestor t, int n) {
+        Set<BitSet> set = internalCladesTaxaOnly(t, n);
+        for (Node leaf : t.getWrappedTree().getExternalNodes()) {
+            if (leaf.getLength() != 0.0) {
+                BitSet singleton = BitSet.newBitSet(n);
+                singleton.set(leaf.getNr());
+                set.add(singleton);
+            }
+        }
+        return set;
+    }
+
+    private static Set<BitSet> internalCladesTaxaOnly(WrappedBeastTreeWithSampledAncestor t, int n) {
+        Set<BitSet> set = new HashSet<>();
+        collectInternalCladesTaxaOnly(t.getWrappedTree().getRoot(), n, set);
+        return set;
+    }
+
+    private static BitSet collectInternalCladesTaxaOnly(Node v, int n, Set<BitSet> internalClades) {
+        if (v.isLeaf()) {
+            BitSet leafBits = BitSet.newBitSet(n);
+            leafBits.set(v.getNr());
+            return leafBits;
+        }
+        BitSet cladeBits = BitSet.newBitSet(n);
+        for (Node child : v.getChildren()) {
+            cladeBits.or(collectInternalCladesTaxaOnly(child, n, internalClades));
+        }
+        internalClades.add(cladeBits);
+        return cladeBits;
     }
 
     /**

--- a/src/main/java/ccd/algorithms/credibleSets/CladeBasedCredibleCCDComputer.java
+++ b/src/main/java/ccd/algorithms/credibleSets/CladeBasedCredibleCCDComputer.java
@@ -78,7 +78,7 @@ public abstract class CladeBasedCredibleCCDComputer extends CredibleCCDComputer 
             // recompute values in partial CCD
             // if (partialCCD instanceof CCD0) {
             partialCCD.resetSumCladeCredibilities();
-            CCD0.setPartitionProbabilities(rootClade);
+            ((CCD0) partialCCD).setPartitionProbabilities(rootClade);
             partialCCD.computeCladeProbabilities();
             // }
 

--- a/src/main/java/ccd/algorithms/credibleSets/ProbabilityBasedCredibleSetComputer.java
+++ b/src/main/java/ccd/algorithms/credibleSets/ProbabilityBasedCredibleSetComputer.java
@@ -32,6 +32,7 @@ public class ProbabilityBasedCredibleSetComputer implements ICredibleSet {
 
     /** The stored probability thresholds determining the credible levels. */
     private double[] sampledProbabilities;
+    private double[] sampledLogProbabilities;
 
     /**
      * A probability-based credible set with default number of sampled trees and default precision (number of thresholds)
@@ -74,7 +75,8 @@ public class ProbabilityBasedCredibleSetComputer implements ICredibleSet {
         }
         this.precision = precision;
 
-        initializeCredibleSetInformation();
+        // initializeCredibleSetInformation();
+        initializeCredibleSetInformationLogSpace();
     }
 
     /* Initialization method. */
@@ -114,16 +116,54 @@ public class ProbabilityBasedCredibleSetComputer implements ICredibleSet {
         // }
     }
 
-    @Override
-    public double getCredibleLevel(Tree tree) {
-        // Double prob = (Double) tree.getRoot().getMetaData(AbstractCCD.PROB_SUBTREE_KEY);
-        double prob = treeDistribution.getProbabilityOfTree(tree);
-        if (prob == 0) {
-            return -1;
+    private void initializeCredibleSetInformationLogSpace() {
+
+        sampledLogProbabilities = new double[numSamples + 1];
+        sampledLogProbabilities[0] = Double.NEGATIVE_INFINITY;
+
+        for (int i = 1; i <= numSamples; i++) {
+            sampledLogProbabilities[i] = treeDistribution.sampleTreeLogProbability();
         }
 
-        int indexOfNextSmallest = findIndexOfNextSmallest(prob) + 1;
-        return (indexOfNextSmallest / (double) sampledProbabilities.length);
+        Arrays.sort(sampledLogProbabilities);
+
+        // reverse (descending order)
+        for (int i = 0; i < sampledLogProbabilities.length / 2; i++) {
+            int j = sampledLogProbabilities.length - 1 - i;
+            double tmp = sampledLogProbabilities[i];
+            sampledLogProbabilities[i] = sampledLogProbabilities[j];
+            sampledLogProbabilities[j] = tmp;
+        }
+
+        if (precision < numSamples) {
+            double[] down = new double[precision];
+            double stepSize = numSamples / (double) precision;
+
+            for (int i = 1; i <= precision; i++) {
+                int sampleIndex = (int) Math.round(i * stepSize);
+                down[i - 1] = sampledLogProbabilities[sampleIndex];
+            }
+
+            sampledLogProbabilities = down;
+        }
+    }
+
+    // @Override
+    // public double getCredibleLevel(Tree tree) {
+    //     double prob = treeDistribution.getProbabilityOfTree(tree);
+    //     if (prob == 0) {
+    //         return -1;
+    //     }
+    //     int indexOfNextSmallest = findIndexOfNextSmallest(prob) + 1;
+    //     return (indexOfNextSmallest / (double) sampledProbabilities.length);
+    // }
+
+    @Override
+    public double getCredibleLevel(Tree tree) {
+        double logProb = treeDistribution.getLogProbabilityOfTree(tree);
+        if (logProb == Double.NEGATIVE_INFINITY) return -1;
+        int index = findIndexOfNextSmallestLogSpace(logProb) + 1;
+        return index / (double) sampledLogProbabilities.length;
     }
 
     /* Helper method. */
@@ -145,6 +185,23 @@ public class ProbabilityBasedCredibleSetComputer implements ICredibleSet {
         }
 
         // System.out.println("result = " + result);
+        return result;
+    }
+
+    private int findIndexOfNextSmallestLogSpace(double targetLogProb) {
+        int left = 0;
+        int right = sampledLogProbabilities.length - 1;
+        int result = right;
+
+        while (left <= right) {
+            int mid = (left + right) / 2;
+            if (targetLogProb > sampledLogProbabilities[mid]) {
+                result = mid;
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        }
         return result;
     }
 
@@ -179,7 +236,6 @@ public class ProbabilityBasedCredibleSetComputer implements ICredibleSet {
                 nums[i] = bucketProbability / meanProbability[i];
             }
         }
-
 
         return nums;
     }

--- a/src/main/java/ccd/algorithms/regularisation/CCD1Regularisor.java
+++ b/src/main/java/ccd/algorithms/regularisation/CCD1Regularisor.java
@@ -9,14 +9,58 @@ public class CCD1Regularisor {
 
     CCDRegularisationStrategy strategy;
     Double value;
+    /** Second pseudocount (beta) for NNI-derived splits under {@link CCDRegularisationStrategy#AdditiveXY}. */
+    Double value2;
 
     public CCD1Regularisor(CCDRegularisationStrategy strategy, double value) {
         this.strategy = strategy;
         this.value = value;
     }
 
+    /**
+     * Two-level additive smoothing: pseudocount {@code value} (alpha) for
+     * observed and split-expanded splits, and {@code value2} (beta) for
+     * NNI-derived splits (those touching an NNI-expanded clade). Intended with
+     * {@link CCDRegularisationStrategy#AdditiveXY}.
+     *
+     * @param strategy regularisation strategy (use AdditiveXY)
+     * @param value    pseudocount alpha for regular splits
+     * @param value2   pseudocount beta for NNI-derived splits
+     */
+    public CCD1Regularisor(CCDRegularisationStrategy strategy, double value, double value2) {
+        this.strategy = strategy;
+        this.value = value;
+        this.value2 = value2;
+    }
+
     public CCD1Regularisor(CCDRegularisationStrategy strategy) {
         this.strategy = strategy;
+    }
+
+    /** Whether a split (parent -&gt; {child0, child1}) is NNI-derived, i.e. touches a novel clade. */
+    public static boolean isNNISplit(Clade parent, CladePartition partition) {
+        return parent.isNNIExpanded()
+                || partition.getChildClades()[0].isNNIExpanded()
+                || partition.getChildClades()[1].isNNIExpanded();
+    }
+
+    /* Two-level additive smoothing for one clade. */
+    private void regulariseAdditiveXY(Clade clade) {
+        double alpha = this.value;
+        double beta = this.value2;
+
+        double denominator = clade.getNumberOfOccurrences();
+        for (CladePartition partition : clade.getPartitions()) {
+            denominator += isNNISplit(clade, partition) ? beta : alpha;
+        }
+
+        for (CladePartition partition : clade.getPartitions()) {
+            if (partition.isCCPSet()) {
+                throw new AssertionError("Cannot regularize CCD1 with set CCPs, only with sample-based ones.");
+            }
+            double addend = isNNISplit(clade, partition) ? beta : alpha;
+            partition.setCCP((partition.getNumberOfOccurrences() + addend) / denominator);
+        }
     }
 
     public void regularise(CCD1 ccd) {
@@ -29,9 +73,15 @@ public class CCD1Regularisor {
                 continue;
             }
 
+            if (strategy == CCDRegularisationStrategy.AdditiveXY) {
+                regulariseAdditiveXY(clade);
+                continue;
+            }
+
             double denominator = clade.getNumberOfOccurrences() + switch (strategy) {
                 case AdditiveOne -> clade.getNumberOfPartitions();
                 case AdditiveX -> clade.getNumberOfPartitions() * value;
+                case AdditiveXY -> throw new AssertionError("AdditiveXY handled separately");
                 case PriorOne -> 1;
                 case PriorScaled -> value;
             };
@@ -62,6 +112,7 @@ public class CCD1Regularisor {
                 double addend = switch (strategy) {
                     case AdditiveOne -> 1;
                     case AdditiveX -> value;
+                    case AdditiveXY -> throw new AssertionError("AdditiveXY handled separately");
                     case PriorOne -> priorProbs[i];
                     case PriorScaled -> priorProbs[i] * value;
                 };

--- a/src/main/java/ccd/algorithms/regularisation/CCDRegularisationStrategy.java
+++ b/src/main/java/ccd/algorithms/regularisation/CCDRegularisationStrategy.java
@@ -3,6 +3,7 @@ package ccd.algorithms.regularisation;
 public enum CCDRegularisationStrategy {
     AdditiveOne("Additive-1"),
     AdditiveX("Additive-"),
+    AdditiveXY("Additive-XY"),
     PriorOne("Prior-1"),
     PriorScaled("Prior-Scaled");
 

--- a/src/main/java/ccd/algorithms/regularisation/KRegCCDParameterOptimiser.java
+++ b/src/main/java/ccd/algorithms/regularisation/KRegCCDParameterOptimiser.java
@@ -1,0 +1,269 @@
+package ccd.algorithms.regularisation;
+
+import beast.base.evolution.tree.Tree;
+import ccd.algorithms.regularisation.NNIHeldOutComparison.FoldAssignment;
+import ccd.model.KRegCCD;
+import org.apache.commons.math4.legacy.analysis.UnivariateFunction;
+import org.apache.commons.math4.legacy.optim.MaxEval;
+import org.apache.commons.math4.legacy.optim.nonlinear.scalar.GoalType;
+import org.apache.commons.math4.legacy.optim.univariate.BrentOptimizer;
+import org.apache.commons.math4.legacy.optim.univariate.SearchInterval;
+import org.apache.commons.math4.legacy.optim.univariate.UnivariateObjectiveFunction;
+import org.apache.commons.math4.legacy.optim.univariate.UnivariatePointValuePair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Selects {@link KRegCCD}'s hyperparameters by maximising <em>cross-validated held-out</em>
+ * tree log-probability — the counterpart of {@link RegCCDParameterOptimiser} (which tunes the
+ * backbone smoothing {@code alpha} alone) for the full-support model's two parameters.
+ *
+ * <p>
+ * The objective is the total log-probability of held-out trees under batched leave-one-tree-out
+ * (B-fold cross-validation): each fold is held out in turn while the backbone is rebuilt on the
+ * rest and scores the fold. Scoring training trees instead would drive {@code mu -> 0} (the
+ * backbone fits them exactly, so any reserved escape mass is pure loss), so the trees scored must
+ * be out of training.
+ *
+ * <p>
+ * The two parameters are optimised jointly but with different search strategies that exploit their
+ * structure:
+ * <ul>
+ *   <li>{@code alpha} (backbone smoothing) changes the clade/split graph, so each value needs a
+ *       full rebuild per fold; it has a sharp interior optimum and is found by Brent's method
+ *       (as in {@link RegCCDParameterOptimiser}).</li>
+ *   <li>{@code mu} (escape probability) does not touch the counts — only {@code eps(C)} re-solves
+ *       from the cached {@code N_j} — so for a fixed {@code alpha} the whole {@code mu} sweep is
+ *       evaluated on one set of trained backbones via
+ *       {@link KRegCCD#getLogProbabilityOfTree(Tree, double)}. Its held-out curve is shallow, so
+ *       it is searched on a (log-spaced) grid and taken at the argmax rather than by a
+ *       derivative-based method that would wander on the flat ridge.</li>
+ * </ul>
+ * For each candidate {@code alpha}, {@code mu} is profiled out (best over the grid); Brent then
+ * maximises that profiled objective over {@code alpha}. When {@link #FIXED_ALPHA} is set, the Brent
+ * search is skipped and only {@code mu} is profiled at that pinned {@code alpha} — a large speedup
+ * (one set of per-fold backbones instead of one per alpha evaluation).
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class KRegCCDParameterOptimiser {
+
+    /** The selected hyperparameters and the cross-validated held-out log-probability at them. */
+    public record Params(double alpha, double mu, double heldOutLogProb) {
+    }
+
+    /** Default number of cross-validation folds. */
+    public static final int DEFAULT_FOLDS = 5;
+
+    /** Reserve depth used for the candidate models (matches {@link KRegCCD#DEFAULT_RESERVE_DEPTH}). */
+    private static final int RESERVE_DEPTH = KRegCCD.DEFAULT_RESERVE_DEPTH;
+
+    /* alpha search interval (strictly positive; mirrors RegCCDParameterOptimiser's range). */
+    private static final double ALPHA_LO = 1e-3;
+    private static final double ALPHA_HI = 2.0;
+    private static final double ALPHA_START = KRegCCD.DEFAULT_ALPHA;
+
+    /* Fixed backbone-smoothing alpha. The Yule50 sweep found the fitted alpha clustered tightly
+     * around 0.4 (per-size medians 0.46/0.40/0.36) and the held-out objective is shallow in alpha,
+     * so the Brent search buys little but costs a full backbone rebuild per alpha evaluation (up to
+     * MAX_ALPHA_EVALS x folds rebuilds). Pinning alpha = 0.4 and profiling only mu collapses that to
+     * one set of per-fold backbones -- the dominant speedup for the 100-rep re-run. Set to null to
+     * restore the Brent search over [ALPHA_LO, ALPHA_HI]. */
+    private static final Double FIXED_ALPHA = 0.4;
+
+    /* mu grid: log-spaced from negligible escape up to the reliability ceiling. The upper bound is
+     * KRegCCD.MU_RELIABLE_MAX, not larger: above it the depth-k reserve approximation breaks down
+     * (the omitted tail grows ~mu^3), and because the held-out objective is scored with tail = 0
+     * (NONE) that breakdown inflates the score ~mu^3 -- which would bias the search toward large
+     * mu. Searching beyond the ceiling is therefore both invalid and misleading.
+     *
+     * The lower bound is 1e-4 (was 1e-3): on large posterior samples the held-out optimum routinely
+     * sat on the old 1e-3 floor (once most clades are seen the data wants very little escape mass),
+     * so the floor was binding rather than interior. MU_GRID is widened from 41 to 61 to keep the
+     * per-decade grid density roughly constant over the now-wider range. A floor warning (below)
+     * flags fits that still pin at the lowered floor. */
+    private static final double MU_LO = 1e-4;
+    private static final double MU_HI = KRegCCD.MU_RELIABLE_MAX;
+    private static final int MU_GRID = 61;
+
+    private static final int MAX_ALPHA_EVALS = 60;
+
+    public static Params optimise(List<Tree> trees) {
+        return optimise(trees, DEFAULT_FOLDS);
+    }
+
+    public static Params optimise(List<Tree> trees, int folds) {
+        // CONTIGUOUS (block) folds, not STRIDED: posterior trees are autocorrelated, so strided folds
+        // leave each held-out tree's near-neighbours in its own training fold, making the CV optimistic
+        // and selecting under-regularised (too-small alpha/mu) parameters. A contiguous held-out block
+        // is far less correlated with its training set, giving an honest held-out objective.
+        return optimise(trees, folds, FoldAssignment.CONTIGUOUS);
+    }
+
+    public static Params optimise(List<Tree> trees, int folds, FoldAssignment assignment) {
+        int n = trees.size();
+        if (n < 2) {
+            throw new IllegalArgumentException("need at least 2 trees to cross-validate, got " + n);
+        }
+        int b = Math.max(2, Math.min(folds, n));
+
+        // Fixed fold partition (only the backbones change with alpha, not the split).
+        List<List<Tree>> trainByFold = new ArrayList<>(b);
+        List<List<Tree>> testByFold = new ArrayList<>(b);
+        for (int f = 0; f < b; f++) {
+            List<Tree> train = new ArrayList<>();
+            List<Tree> test = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                boolean isTest = switch (assignment) {
+                    case STRIDED -> (i % b == f);
+                    case CONTIGUOUS -> (i >= (int) ((long) f * n / b)) && (i < (int) ((long) (f + 1) * n / b));
+                };
+                (isTest ? test : train).add(trees.get(i));
+            }
+            trainByFold.add(train);
+            testByFold.add(test);
+        }
+
+        double[] muGrid = logspace(MU_LO, MU_HI, MU_GRID);
+
+        double alphaStar;
+        if (FIXED_ALPHA != null) {
+            // alpha pinned (see FIXED_ALPHA): skip the Brent search and profile only mu.
+            alphaStar = FIXED_ALPHA;
+        } else {
+            UnivariateFunction profiled = alpha -> {
+                double[] best = bestMuLogProb(trainByFold, testByFold, alpha, muGrid);
+                System.out.println(String.format(
+                        "  testing alpha = %.5f -> best mu = %.5f, held-out logP = %.5f",
+                        alpha, best[0], best[1]));
+                return best[1];
+            };
+
+            BrentOptimizer optimiser = new BrentOptimizer(1e-4, 1e-4);
+            UnivariatePointValuePair sol = optimiser.optimize(
+                    new MaxEval(MAX_ALPHA_EVALS),
+                    new UnivariateObjectiveFunction(profiled),
+                    GoalType.MAXIMIZE,
+                    new SearchInterval(ALPHA_LO, ALPHA_HI, ALPHA_START));
+            alphaStar = sol.getPoint();
+        }
+
+        double[] best = bestMuLogProb(trainByFold, testByFold, alphaStar, muGrid);
+        System.out.println(String.format(
+                "KRegCCD optimised: alpha = %.5f, mu = %.5f, held-out logP = %.5f",
+                alphaStar, best[0], best[1]));
+        if (best[0] >= MU_HI * (1 - 1e-9)) {
+            System.err.println("WARNING: held-out probability is still increasing in mu at the "
+                    + "reliability ceiling mu = " + MU_HI + " (KRegCCD.MU_RELIABLE_MAX); the data "
+                    + "wants more escape mass than the depth-k approximation can validly provide. "
+                    + "Treat mu = " + MU_HI + " as a capped estimate, not an interior optimum.");
+        }
+        if (best[0] <= MU_LO * (1 + 1e-9)) {
+            System.err.println("WARNING: held-out probability is still increasing as mu decreases at "
+                    + "the search floor mu = " + MU_LO + "; the data wants even less escape mass than "
+                    + "this. Treat mu = " + MU_LO + " as a capped (non-interior) estimate.");
+        }
+        return new Params(alphaStar, best[0], best[1]);
+    }
+
+    /**
+     * Optimise mu alone, given an alpha value
+     */
+    public static MuResult optimiseMu(List<Tree> trees, int folds, FoldAssignment assignment, double alpha) {
+        int n = trees.size();
+        if (n < 2) throw new IllegalArgumentException("need at least 2 trees to cross-validate, got " + n);
+        int b = Math.max(2, Math.min(folds, n));
+        List<List<Tree>> trainByFold = new ArrayList<>(b);
+        List<List<Tree>> testByFold = new ArrayList<>(b);
+        for (int f = 0; f < b; f++) {
+            List<Tree> train = new ArrayList<>();
+            List<Tree> test = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                boolean isTest = switch (assignment) {
+                    case STRIDED -> (i % b == f);
+                    case CONTIGUOUS -> (i >= (int) ((long) f * n / b)) && (i < (int) ((long) (f + 1) * n / b));
+                };
+                (isTest ? test : train).add(trees.get(i));
+            }
+            trainByFold.add(train);
+            testByFold.add(test);
+        }
+        double[] muGrid = logspace(MU_LO, MU_HI, MU_GRID);
+        double[] best = bestMuLogProb(trainByFold, testByFold, alpha, muGrid);
+        return new MuResult(best[0], best[1]);
+    }
+
+    public record MuResult(double mu, double heldOutLogProb) {
+    }
+
+    /**
+     * The cross-validated held-out total log-probability at a fixed {@code (alpha, mu)} — the
+     * objective the optimiser maximises. Rebuilds the per-fold backbones, so prefer the internal
+     * grid path for a full search; this is for evaluating or comparing individual points.
+     */
+    public static double crossValidatedLogProb(List<Tree> trees, int folds, FoldAssignment assignment,
+                                               double alpha, double mu) {
+        int n = trees.size();
+        int b = Math.max(2, Math.min(folds, n));
+        double total = 0.0;
+        for (int f = 0; f < b; f++) {
+            List<Tree> train = new ArrayList<>();
+            List<Tree> test = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                boolean isTest = switch (assignment) {
+                    case STRIDED -> (i % b == f);
+                    case CONTIGUOUS -> (i >= (int) ((long) f * n / b)) && (i < (int) ((long) (f + 1) * n / b));
+                };
+                (isTest ? test : train).add(trees.get(i));
+            }
+            KRegCCD model = new KRegCCD(train, 0.0, KRegCCD.DEFAULT_MU, alpha,
+                    RESERVE_DEPTH, KRegCCD.TailMode.NONE);
+            for (Tree t : test) {
+                total += model.getLogProbabilityOfTree(t, mu);
+            }
+        }
+        return total;
+    }
+
+    /**
+     * For a fixed {@code alpha}: builds one NONE-tail backbone per fold and returns
+     * {@code {argmax mu over the grid, that held-out total log-probability}}. All grid values reuse
+     * the same backbones — {@code mu} only re-solves {@code eps} from the cached counts.
+     */
+    private static double[] bestMuLogProb(List<List<Tree>> trainByFold, List<List<Tree>> testByFold,
+                                          double alpha, double[] muGrid) {
+        int b = trainByFold.size();
+        KRegCCD[] models = new KRegCCD[b];
+        for (int f = 0; f < b; f++) {
+            // mu here is a placeholder: scoring overrides it via getLogProbabilityOfTree(tree, mu).
+            models[f] = new KRegCCD(trainByFold.get(f), 0.0, KRegCCD.DEFAULT_MU, alpha,
+                    RESERVE_DEPTH, KRegCCD.TailMode.NONE);
+        }
+        double bestMu = muGrid[0];
+        double bestLogProb = Double.NEGATIVE_INFINITY;
+        for (double mu : muGrid) {
+            double total = 0.0;
+            for (int f = 0; f < b; f++) {
+                for (Tree t : testByFold.get(f)) {
+                    total += models[f].getLogProbabilityOfTree(t, mu);
+                }
+            }
+            if (total > bestLogProb) {
+                bestLogProb = total;
+                bestMu = mu;
+            }
+        }
+        return new double[]{bestMu, bestLogProb};
+    }
+
+    private static double[] logspace(double lo, double hi, int n) {
+        double[] grid = new double[n];
+        double logLo = Math.log(lo);
+        double logHi = Math.log(hi);
+        for (int i = 0; i < n; i++) {
+            grid[i] = Math.exp(logLo + (logHi - logLo) * i / (n - 1));
+        }
+        return grid;
+    }
+}

--- a/src/main/java/ccd/algorithms/regularisation/MRegCCDParameterOptimiser.java
+++ b/src/main/java/ccd/algorithms/regularisation/MRegCCDParameterOptimiser.java
@@ -1,0 +1,120 @@
+package ccd.algorithms.regularisation;
+
+import beast.base.evolution.tree.Tree;
+import ccd.algorithms.regularisation.NNIHeldOutComparison.FoldAssignment;
+import ccd.model.MRegCCD;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Selects the one hyperparameter {@code mu} of {@link MRegCCD} by maximising <em>cross-validated
+ * held-out</em> tree log-probability — the single-parameter counterpart of
+ * {@link KRegCCDParameterOptimiser}.
+ *
+ * <p>The objective is the total log-probability of held-out trees under {@code b}-fold
+ * cross-validation: each fold is held out in turn while the backbone is rebuilt on the rest and
+ * scores the fold. Scoring training trees instead would drive {@code mu -> 0} (the backbone fits them
+ * exactly, so any reserved escape mass is pure loss), so the scored trees must be out of training.
+ *
+ * <p>Folds are <strong>CONTIGUOUS</strong> blocks by default, not strided: posterior trees are
+ * autocorrelated, so strided folds leave each held-out tree's near-neighbours in its own training
+ * fold and make the CV optimistic. A contiguous held-out block is far less correlated with its
+ * training set.
+ *
+ * <p>{@code mu} does not touch the clade counts — only {@code eps(C)} re-solves — so the whole grid is
+ * evaluated on one set of per-fold backbones via {@link MRegCCD#getLogProbabilityOfTree(Tree, double)}.
+ * The models are built with the tail correction ON: unlike the un-tailed score the tail keeps each
+ * candidate {@code mu} properly normalised, so the held-out objective is honest (a tail-free score
+ * super-normalises and would bias the search toward large {@code mu}).
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class MRegCCDParameterOptimiser {
+
+    /** The selected escape probability and the cross-validated held-out log-probability at it. */
+    public record MuResult(double mu, double heldOutLogProb) {
+    }
+
+    /** Default number of cross-validation folds. */
+    public static final int DEFAULT_FOLDS = 5;
+
+    /* mu grid: log-spaced. The lower bound is negligible escape; the upper bound is generous (the
+     * per-new-split model spends more escape mass per region than KRegCCD, so its optimum sits
+     * higher). MRegCCD self-normalises via the geometric tail at every mu, so there is no hard
+     * reliability ceiling as in KRegCCD's tail-free search; floor/ceiling warnings still flag a
+     * non-interior optimum. */
+    private static final double MU_LO = 1e-4;
+    private static final double MU_HI = 0.2;
+    private static final int MU_GRID = 61;
+
+    public static MuResult optimiseMu(List<Tree> trees) {
+        return optimiseMu(trees, DEFAULT_FOLDS, FoldAssignment.CONTIGUOUS);
+    }
+
+    public static MuResult optimiseMu(List<Tree> trees, int folds, FoldAssignment assignment) {
+        int n = trees.size();
+        if (n < 2) {
+            throw new IllegalArgumentException("need at least 2 trees to cross-validate, got " + n);
+        }
+        int b = Math.max(2, Math.min(folds, n));
+
+        List<List<Tree>> trainByFold = new ArrayList<>(b);
+        List<List<Tree>> testByFold = new ArrayList<>(b);
+        for (int f = 0; f < b; f++) {
+            List<Tree> train = new ArrayList<>();
+            List<Tree> test = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                boolean isTest = switch (assignment) {
+                    case STRIDED -> (i % b == f);
+                    case CONTIGUOUS -> (i >= (int) ((long) f * n / b)) && (i < (int) ((long) (f + 1) * n / b));
+                };
+                (isTest ? test : train).add(trees.get(i));
+            }
+            trainByFold.add(train);
+            testByFold.add(test);
+        }
+
+        // One backbone per fold (tail ON so each mu is properly normalised); reused across the grid.
+        MRegCCD[] models = new MRegCCD[b];
+        for (int f = 0; f < b; f++) {
+            models[f] = new MRegCCD(trainByFold.get(f), 0.0, MRegCCD.DEFAULT_MU,
+                    MRegCCD.DEFAULT_RESERVE_DEPTH, true);
+        }
+
+        double[] muGrid = logspace(MU_LO, MU_HI, MU_GRID);
+        double bestMu = muGrid[0];
+        double bestLogProb = Double.NEGATIVE_INFINITY;
+        for (double mu : muGrid) {
+            double total = 0.0;
+            for (int f = 0; f < b; f++) {
+                for (Tree t : testByFold.get(f)) {
+                    total += models[f].getLogProbabilityOfTree(t, mu);
+                }
+            }
+            if (total > bestLogProb) {
+                bestLogProb = total;
+                bestMu = mu;
+            }
+        }
+        if (bestMu >= MU_HI * (1 - 1e-9)) {
+            System.err.println("WARNING: MRegCCD held-out logP still rising at the mu ceiling "
+                    + MU_HI + "; treat as a capped estimate.");
+        }
+        if (bestMu <= MU_LO * (1 + 1e-9)) {
+            System.err.println("WARNING: MRegCCD held-out logP still rising as mu falls to the floor "
+                    + MU_LO + "; treat as a capped estimate.");
+        }
+        return new MuResult(bestMu, bestLogProb);
+    }
+
+    private static double[] logspace(double lo, double hi, int n) {
+        double[] grid = new double[n];
+        double logLo = Math.log(lo);
+        double logHi = Math.log(hi);
+        for (int i = 0; i < n; i++) {
+            grid[i] = Math.exp(logLo + (logHi - logLo) * i / (n - 1));
+        }
+        return grid;
+    }
+}

--- a/src/main/java/ccd/algorithms/regularisation/NNICladeExpander.java
+++ b/src/main/java/ccd/algorithms/regularisation/NNICladeExpander.java
@@ -1,0 +1,128 @@
+package ccd.algorithms.regularisation;
+
+import ccd.algorithms.NNICladeExpansion;
+import ccd.algorithms.NNICladeExpansion.NovelClade;
+import ccd.algorithms.NNICladeExpansion.PairingMode;
+import ccd.algorithms.NNICladeExpansion.Provenance;
+import ccd.model.AbstractCCD;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+
+/**
+ * Applies the clade-level NNI expansion to a CCD graph by inserting the novel
+ * clades it generates, together with the splits NNI implies.
+ *
+ * <p>
+ * This is the clade-level analogue of {@link CCDExpansion}: where
+ * {@code CCDExpansion} adds unobserved <em>splits</em> among already-present
+ * clades, this adds unobserved <em>clades</em> (and the splits the NNI move
+ * implies) so that a CCD1/regCCD can assign nonzero probability to trees that
+ * contain a clade no sampled tree had. The enumeration is done read-only by
+ * {@link NNICladeExpansion}; here we mutate the graph.
+ * </p>
+ *
+ * <p>
+ * For each novel clade {@code K = kept ∪ sibling} with provenance parent
+ * {@code P} and dropped grandchild {@code B}, we add the seed split
+ * {@code K -> {kept, sibling}} and the parent split {@code P -> {K, B}}. No
+ * conditional probabilities are assigned here; a subsequent
+ * {@link CCD1Regularisor} prices the new (zero-count) splits with the same
+ * additive-{@code alpha} smoothing as the observed and {@code CCDExpansion}
+ * splits. A novel clade carries no marginal parameter --- under the CCD1
+ * parameterisation its probability is induced by the product of conditional
+ * clade probabilities along the path to it.
+ * </p>
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class NNICladeExpander {
+
+    private final PairingMode mode;
+
+    private int cladesAdded = 0;
+    private int seedSplitsAdded = 0;
+    private int parentSplitsAdded = 0;
+
+    /**
+     * @param mode how splits are paired into NNI recombinations
+     *             ({@link PairingMode#GRAPH_WIDE} or
+     *             {@link PairingMode#CO_OCCURRING})
+     */
+    public NNICladeExpander(PairingMode mode) {
+        this.mode = mode;
+    }
+
+    /**
+     * Enumerates the NNI-reachable novel clades of the given CCD and inserts
+     * them, with their NNI-implied splits, into the CCD graph.
+     *
+     * @param ccd the CCD to expand in place (its observed splits are used for
+     *            the enumeration, so call before any split-level expansion)
+     */
+    public void expandClades(AbstractCCD ccd) {
+        NNICladeExpansion enumeration = new NNICladeExpansion(ccd, mode).compute();
+
+        for (NovelClade novel : enumeration.getNovelClades()) {
+            Clade k = ccd.getOrCreateClade(novel.taxa);
+            k.setNNIExpanded(true);
+            cladesAdded++;
+
+            for (Provenance prov : novel.provenances) {
+                // NNI seed split of the novel clade: K -> {kept, sibling}
+                if (k.getCladePartition(prov.kept(), prov.sibling()) == null) {
+                    k.createCladePartition(prov.kept(), prov.sibling());
+                    seedSplitsAdded++;
+                }
+                // recombined parent split: P -> {K, dropped}
+                Clade parent = prov.parent();
+                if (parent.getCladePartition(k, prov.dropped()) == null) {
+                    parent.createCladePartition(k, prov.dropped());
+                    parentSplitsAdded++;
+                }
+            }
+        }
+
+        ccd.setCacheAsDirty();
+    }
+
+    /** @return number of novel clades inserted */
+    public int getCladesAdded() {
+        return cladesAdded;
+    }
+
+    /** @return number of NNI seed splits inserted */
+    public int getSeedSplitsAdded() {
+        return seedSplitsAdded;
+    }
+
+    /** @return number of recombined parent splits inserted */
+    public int getParentSplitsAdded() {
+        return parentSplitsAdded;
+    }
+
+    /**
+     * Sets the conditional clade probability to 1 for every clade that has a
+     * single split and no observed occurrences. Such clades (e.g. novel cherries
+     * or novel clades with only their NNI seed split) are skipped by
+     * {@link CCD1Regularisor}, and their count-based CCP would be 0/0; this makes
+     * them deterministic, as there is only one way to resolve them.
+     *
+     * <p>
+     * Call after regularisation. Existing observed clades with a single split
+     * have positive occurrences, so their CCP is well defined and they are left
+     * untouched.
+     * </p>
+     *
+     * @param ccd the CCD whose novel single-split clades are finalised
+     */
+    public static void fixZeroOccurrenceSingletonCCPs(AbstractCCD ccd) {
+        for (Clade clade : ccd.getClades()) {
+            if (clade.getNumberOfPartitions() == 1 && clade.getNumberOfOccurrences() == 0) {
+                CladePartition only = clade.getPartitions().get(0);
+                if (!only.isCCPSet()) {
+                    only.setCCP(1.0);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ccd/algorithms/regularisation/NNIHeldOutComparison.java
+++ b/src/main/java/ccd/algorithms/regularisation/NNIHeldOutComparison.java
@@ -1,0 +1,376 @@
+package ccd.algorithms.regularisation;
+
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.algorithms.NNICladeExpansion.PairingMode;
+import ccd.model.KRegCCD;
+import ccd.model.NNIRegCCD;
+import ccd.model.RegCCD;
+import ccd.tools.CCDToolUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Compares the out-of-sample coverage of regCCD and NNI-expanded regCCD: how many
+ * held-out trees receive nonzero probability (i.e. are <em>covered</em>) and the
+ * mean log probability over the covered trees.
+ *
+ * <p>
+ * This targets the residual regCCD limitation that trees containing an unsampled
+ * clade receive zero probability. The NNI clade expansion adds plausible unseen
+ * clades, so it should reduce the zero-probability count. Scoring uses the
+ * regularised model directly ({@code getLogProbabilityOfTree}); held-out trees
+ * are genuinely out-of-training, so no leave-one-out count adjustment is needed.
+ * </p>
+ *
+ * <p>
+ * Two evaluation protocols are provided:
+ * <ul>
+ * <li>{@link #compare} --- train on one set, score an independent held-out set
+ * (e.g.\ a separate chain, or one file split in two);</li>
+ * <li>{@link #crossValidate} --- <em>batched leave-one-tree-out</em>: B-fold
+ * cross-validation that rebuilds the (NNI-)regCCD on each training fold and
+ * scores the held-out fold. This approximates true leave-one-tree-out with only
+ * B rebuilds instead of N. A full rebuild per fold is required because the NNI
+ * clade set depends on which trees are present, so the memoised count-subtraction
+ * shortcut used for plain regCCD does not apply to the NNI model.</li>
+ * </ul>
+ * </p>
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class NNIHeldOutComparison {
+
+    /**
+     * Coverage / mean-log-prob summary for one model on a held-out set.
+     *
+     * @param model              model description
+     * @param total              number of held-out trees
+     * @param covered            number assigned nonzero probability
+     * @param meanLogProbCovered mean log prob over this model's covered trees
+     * @param meanLogProbCommon  mean log prob over trees covered by all models
+     *                           (the fair, same-denominator sharpness metric)
+     */
+    public record Result(String model, int total, int covered,
+                         double meanLogProbCovered, double meanLogProbCommon) {
+        public double coverageFraction() {
+            return (total == 0) ? 0 : covered / (double) total;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                    "%-24s covered %5d / %-5d (%5.1f%%)   logP/own = %9.4f   logP/common = %9.4f",
+                    model, covered, total, 100 * coverageFraction(),
+                    meanLogProbCovered, meanLogProbCommon);
+        }
+    }
+
+    /** A named recipe for building a (Reg)CCD from a set of training trees. */
+    private record ModelSpec(String label, Function<List<Tree>, RegCCD> builder) {
+    }
+
+    /**
+     * How trees are assigned to cross-validation folds.
+     * <ul>
+     * <li>{@link #STRIDED}: tree {@code i} goes to fold {@code i mod B}. With an
+     * autocorrelated chain this keeps each held-out tree's neighbours in
+     * training, so it tracks true leave-one-tree-out (the default).</li>
+     * <li>{@link #CONTIGUOUS}: fold {@code f} is a contiguous block. This removes
+     * whole correlated stretches from training, giving a more pessimistic
+     * (blocked-CV) estimate that does <em>not</em> approximate LOTO.</li>
+     * </ul>
+     */
+    public enum FoldAssignment {STRIDED, CONTIGUOUS}
+
+    /** The models compared: baseline regCCD, NNI (both modes), and a co-occurring beta sweep. */
+    private static List<ModelSpec> modelSpecs(double alpha) {
+        List<ModelSpec> specs = new ArrayList<>();
+        specs.add(new ModelSpec("regCCD", tr -> new RegCCD(tr, 0.0, alpha)));
+        for (PairingMode mode : PairingMode.values()) {
+            specs.add(new ModelSpec("NNIRegCCD[" + mode + "]",
+                    tr -> new NNIRegCCD(tr, 0.0, mode, alpha)));
+        }
+        for (double beta : new double[]{alpha / 4, alpha / 20}) {
+            specs.add(new ModelSpec(String.format("NNIRegCCD[CO_OCCURRING,b=%.3f]", beta),
+                    tr -> new NNIRegCCD(tr, 0.0, PairingMode.CO_OCCURRING, alpha, beta)));
+        }
+        // full-support KRegCCD (reserve depth 2); compare the three tail modes to
+        // show the normalisation effect on mean logP: NONE (super-normalised),
+        // BOUND (upper bound, sub-normalised), SAMPLED (Knuth, near-exact)
+        for (double mu : new double[]{0.01, 0.05, 0.1, 0.2}) {
+            specs.add(new ModelSpec(String.format("KRegCCD[rd=2,none,mu=%.2f]", mu),
+                    tr -> new KRegCCD(tr, 0.0, mu, alpha, 2, KRegCCD.TailMode.NONE)));
+            specs.add(new ModelSpec(String.format("KRegCCD[rd=2,bound,mu=%.2f]", mu),
+                    tr -> new KRegCCD(tr, 0.0, mu, alpha, 2, KRegCCD.TailMode.BOUND)));
+            specs.add(new ModelSpec(String.format("KRegCCD[rd=2,sampled,mu=%.2f]", mu),
+                    tr -> new KRegCCD(tr, 0.0, mu, alpha, 2, KRegCCD.TailMode.SAMPLED)));
+        }
+        return specs;
+    }
+
+    /* Per-tree log probabilities aligned with the given list. */
+    private static double[] logProbs(RegCCD ccd, List<Tree> trees) {
+        double[] lp = new double[trees.size()];
+        for (int i = 0; i < trees.size(); i++) {
+            lp[i] = ccd.getLogProbabilityOfTree(trees.get(i));
+        }
+        return lp;
+    }
+
+    /* Turn per-model held-out log probabilities into coverage / sharpness results. */
+    private static List<Result> aggregate(List<String> labels, List<double[]> logs) {
+        int n = logs.isEmpty() ? 0 : logs.get(0).length;
+
+        boolean[] common = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            common[i] = true;
+            for (double[] lp : logs) {
+                if (lp[i] == Double.NEGATIVE_INFINITY) {
+                    common[i] = false;
+                    break;
+                }
+            }
+        }
+
+        List<Result> results = new ArrayList<>();
+        for (int m = 0; m < labels.size(); m++) {
+            double[] lp = logs.get(m);
+            int covered = 0, commonCount = 0;
+            double sumOwn = 0.0, sumCommon = 0.0;
+            for (int i = 0; i < lp.length; i++) {
+                if (lp[i] != Double.NEGATIVE_INFINITY) {
+                    covered++;
+                    sumOwn += lp[i];
+                }
+                if (common[i]) {
+                    sumCommon += lp[i];
+                    commonCount++;
+                }
+            }
+            double meanOwn = (covered == 0) ? Double.NaN : sumOwn / covered;
+            double meanCommon = (commonCount == 0) ? Double.NaN : sumCommon / commonCount;
+            results.add(new Result(labels.get(m), n, covered, meanOwn, meanCommon));
+        }
+        return results;
+    }
+
+    /**
+     * Trains each model on {@code training} and scores {@code heldOut}.
+     *
+     * @param training training trees
+     * @param heldOut  independent held-out trees
+     * @param alpha    additive-smoothing pseudocount used for all models
+     * @return one report line per model
+     */
+    public static List<Result> compare(List<Tree> training, List<Tree> heldOut, double alpha) {
+        List<ModelSpec> specs = modelSpecs(alpha);
+        List<String> labels = new ArrayList<>();
+        List<double[]> logs = new ArrayList<>();
+        for (ModelSpec spec : specs) {
+            labels.add(spec.label());
+            logs.add(logProbs(spec.builder().apply(training), heldOut));
+        }
+        return aggregate(labels, logs);
+    }
+
+    /**
+     * Batched leave-one-tree-out using {@link FoldAssignment#STRIDED} folds.
+     *
+     * @param trees all trees (post burn-in)
+     * @param folds number of cross-validation folds (B)
+     * @param alpha additive-smoothing pseudocount used for all models
+     * @return one aggregated report line per model
+     */
+    public static List<Result> crossValidate(List<Tree> trees, int folds, double alpha) {
+        return crossValidate(trees, folds, alpha, FoldAssignment.STRIDED);
+    }
+
+    /**
+     * Batched leave-one-tree-out: B-fold cross-validation. Each fold is held out
+     * in turn while every model is rebuilt on the remaining trees and scores the
+     * held-out fold, so each tree is scored exactly once, out-of-training. A full
+     * rebuild per fold is required because the NNI clade set depends on which
+     * trees are present.
+     *
+     * <p>
+     * To approximate true leave-one-tree-out use {@link FoldAssignment#STRIDED}
+     * (the default): with an autocorrelated sample it keeps each held-out tree's
+     * neighbours in training, as LOTO does, and converges to the LOTO estimate at
+     * much smaller {@code folds} than contiguous blocks. Either way the estimate
+     * converges to LOTO as {@code folds -> N}.
+     * </p>
+     *
+     * @param trees      all trees (post burn-in)
+     * @param folds      number of cross-validation folds (B)
+     * @param alpha      additive-smoothing pseudocount used for all models
+     * @param assignment how trees are assigned to folds
+     * @return one aggregated report line per model
+     */
+    public static List<Result> crossValidate(List<Tree> trees, int folds, double alpha,
+                                             FoldAssignment assignment) {
+        int n = trees.size();
+        List<ModelSpec> specs = modelSpecs(alpha);
+        double[][] logs = new double[specs.size()][n];
+
+        for (int f = 0; f < folds; f++) {
+            List<Tree> train = new ArrayList<>(n);
+            List<Integer> testIdx = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                boolean isTest = switch (assignment) {
+                    case STRIDED -> (i % folds == f);
+                    case CONTIGUOUS -> (i >= (int) ((long) f * n / folds))
+                            && (i < (int) ((long) (f + 1) * n / folds));
+                };
+                if (isTest) {
+                    testIdx.add(i);
+                } else {
+                    train.add(trees.get(i));
+                }
+            }
+
+            for (int m = 0; m < specs.size(); m++) {
+                RegCCD model = specs.get(m).builder().apply(train);
+                for (int i : testIdx) {
+                    logs[m][i] = model.getLogProbabilityOfTree(trees.get(i));
+                }
+            }
+            System.out.println("  fold " + (f + 1) + "/" + folds + " done ("
+                    + testIdx.size() + " held out, " + train.size() + " train)");
+        }
+
+        List<String> labels = new ArrayList<>();
+        List<double[]> logList = new ArrayList<>();
+        for (int m = 0; m < specs.size(); m++) {
+            labels.add(specs.get(m).label());
+            logList.add(logs[m]);
+        }
+        return aggregate(labels, logList);
+    }
+
+    private static List<Tree> loadTrees(String path, int burninPercentage) throws Exception {
+        TreeAnnotator.MemoryFriendlyTreeSet treeSet = CCDToolUtil.getTreeSet(path, burninPercentage);
+        List<Tree> trees = new ArrayList<>();
+        treeSet.reset();
+        while (treeSet.hasNext()) {
+            trees.add(treeSet.next());
+        }
+        return trees;
+    }
+
+    /**
+     * CLI. Forms:
+     * <ul>
+     * <li>{@code <train.trees> <heldout.trees> [burnin%] [alpha]} --- train on
+     * one file, evaluate on an independent file;</li>
+     * <li>{@code <all.trees> [burnin%] [alpha]} --- split one file into first
+     * (train) and second (held-out) half;</li>
+     * <li>{@code cv <all.trees> <folds> [burnin%] [alpha]} --- batched
+     * leave-one-tree-out (B-fold cross-validation).</li>
+     * </ul>
+     *
+     * @param args see above
+     * @throws Exception if a tree file cannot be read
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length >= 1 && args[0].equals("calib")) {
+            // calib <train.trees> [<heldout.trees>] [burnin%] [alpha]
+            // Compares KRegCCD's model mass on novel-clade trees against the
+            // empirical fraction of held-out trees that contain a novel clade.
+            boolean twoFiles = args.length >= 3 && args[2].endsWith(".trees");
+            int ai = twoFiles ? 3 : 2;
+            int burnin = (args.length > ai) ? Integer.parseInt(args[ai]) : 10;
+            double alpha = (args.length > ai + 1) ? Double.parseDouble(args[ai + 1]) : NNIRegCCD.DEFAULT_ALPHA;
+            List<Tree> train, heldOut;
+            if (twoFiles) {
+                train = loadTrees(args[1], burnin);
+                heldOut = loadTrees(args[2], burnin);
+            } else {
+                List<Tree> all = loadTrees(args[1], burnin);
+                int half = all.size() / 2;
+                train = new ArrayList<>(all.subList(0, half));
+                heldOut = new ArrayList<>(all.subList(half, all.size()));
+            }
+            // empirical novel-clade fraction (depends only on the expanded clade set)
+            KRegCCD ref = new KRegCCD(train, 0.0, 0.01, alpha, 2, KRegCCD.TailMode.NONE);
+            int novel = 0;
+            for (Tree t : heldOut) {
+                if (ref.containsNovelClade(t)) {
+                    novel++;
+                }
+            }
+            double empirical = novel / (double) heldOut.size();
+            System.out.printf("calibration: train = %d, held-out = %d, alpha = %.3f%n",
+                    train.size(), heldOut.size(), alpha);
+            System.out.printf("empirical novel-clade fraction = %.4f (%d/%d)%n",
+                    empirical, novel, heldOut.size());
+            System.out.println("  mu       model P(novel)  empirical  ratio   mean logP/tree");
+            for (double mu : new double[]{0.002, 0.003, 0.0035, 0.004, 0.0045, 0.005, 0.006, 0.01}) {
+                KRegCCD m = new KRegCCD(train, 0.0, mu, alpha, 2, KRegCCD.TailMode.NONE);
+                double pNovel = m.getNovelCladeProbability();
+                double sumLogP = 0.0;
+                for (Tree t : heldOut) {
+                    sumLogP += m.getLogProbabilityOfTree(t);
+                }
+                double meanLogP = sumLogP / heldOut.size();
+                System.out.printf("  %-7.3f  %12.4f   %8.4f  %.2fx   %10.4f%n",
+                        mu, pNovel, empirical, pNovel / empirical, meanLogP);
+            }
+            return;
+        }
+        if (args.length >= 1 && args[0].equals("cv")) {
+            if (args.length < 3) {
+                System.err.println("Usage: NNIHeldOutComparison cv <all.trees> <folds> [burnin%] [alpha] [strided|contiguous]");
+                System.exit(1);
+            }
+            int folds = Integer.parseInt(args[2]);
+            int burnin = (args.length >= 4) ? Integer.parseInt(args[3]) : 10;
+            double alpha = (args.length >= 5) ? Double.parseDouble(args[4]) : NNIRegCCD.DEFAULT_ALPHA;
+            FoldAssignment assignment = (args.length >= 6)
+                    ? FoldAssignment.valueOf(args[5].toUpperCase()) : FoldAssignment.STRIDED;
+            List<Tree> all = loadTrees(args[1], burnin);
+            System.out.println(folds + "-fold cross-validation (" + assignment
+                    + "), alpha = " + alpha + ", " + all.size() + " trees");
+            for (Result result : crossValidate(all, folds, alpha, assignment)) {
+                System.out.println(result);
+            }
+            return;
+        }
+
+        if (args.length < 1) {
+            System.err.println("Usage: NNIHeldOutComparison <train.trees> <heldout.trees> [burnin%] [alpha]");
+            System.err.println("   or: NNIHeldOutComparison <all.trees> [burnin%] [alpha]   (split in half)");
+            System.err.println("   or: NNIHeldOutComparison cv <all.trees> <folds> [burnin%] [alpha]");
+            System.exit(1);
+        }
+
+        List<Tree> training;
+        List<Tree> heldOut;
+        double alpha;
+        int burnin;
+
+        boolean twoFiles = args.length >= 2 && args[1].endsWith(".trees");
+        if (twoFiles) {
+            burnin = (args.length >= 3) ? Integer.parseInt(args[2]) : 10;
+            alpha = (args.length >= 4) ? Double.parseDouble(args[3]) : NNIRegCCD.DEFAULT_ALPHA;
+            training = loadTrees(args[0], burnin);
+            heldOut = loadTrees(args[1], burnin);
+        } else {
+            burnin = (args.length >= 2) ? Integer.parseInt(args[1]) : 10;
+            alpha = (args.length >= 3) ? Double.parseDouble(args[2]) : NNIRegCCD.DEFAULT_ALPHA;
+            List<Tree> all = loadTrees(args[0], burnin);
+            int half = all.size() / 2;
+            training = new ArrayList<>(all.subList(0, half));
+            heldOut = new ArrayList<>(all.subList(half, all.size()));
+            System.out.println("Split one file: " + training.size() + " train / " + heldOut.size() + " held-out");
+        }
+
+        System.out.println("alpha = " + alpha + ", training = " + training.size()
+                + " trees, held-out = " + heldOut.size() + " trees");
+        for (Result result : compare(training, heldOut, alpha)) {
+            System.out.println(result);
+        }
+    }
+}

--- a/src/main/java/ccd/algorithms/regularisation/NNIRegCCDOptimiser.java
+++ b/src/main/java/ccd/algorithms/regularisation/NNIRegCCDOptimiser.java
@@ -1,0 +1,435 @@
+package ccd.algorithms.regularisation;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.algorithms.NNICladeExpansion.PairingMode;
+import ccd.model.AbstractCCD;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import ccd.model.NNIRegCCD;
+import ccd.model.bitsets.BitSet;
+import ccd.tools.CCDToolUtil;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Selects the two-level smoothing pseudocounts ({@code alpha} for observed and
+ * split-expanded splits, {@code beta} for NNI-derived splits) of an
+ * {@link NNIRegCCD} by maximising the mean held-out log probability under
+ * batched (strided) leave-one-tree-out.
+ *
+ * <p>
+ * The pseudocounts do not change the clade/split graph, only the smoothing, so
+ * the expensive per-fold graph build is done once. For each held-out tree we
+ * extract a lightweight <em>scoring trace</em> (the raw counts and NNI-flag at
+ * each multi-split node it traverses) and discard the graph; the objective at any
+ * {@code (alpha, beta)} is then a closed-form sum over those traces:
+ * </p>
+ * <pre>
+ *   log CCP(S) = log( f(S) + w )  -  log( f(C) + alpha*|R(C)| + beta*|N(C)| ),
+ *               w = beta if S is NNI-derived else alpha,
+ * </pre>
+ * with single-split clades contributing a deterministic factor of 1. Coverage is
+ * independent of {@code (alpha, beta)} (any positive values keep every split
+ * positive), so the objective is a fixed-denominator mean over the covered
+ * held-out trees and the optimisation cannot trade coverage for sharpness.
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class NNIRegCCDOptimiser {
+
+    /** The per-node contribution of one multi-split clade to a tree's log probability. */
+    public record Factor(int fS, int fC, int regCount, int nniCount, boolean nni) {
+        double logCCP(double alpha, double beta) {
+            double w = nni ? beta : alpha;
+            return Math.log(fS + w) - Math.log(fC + alpha * regCount + beta * nniCount);
+        }
+    }
+
+    /** Result of an (alpha, beta) optimisation for one pairing mode. */
+    public record OptResult(PairingMode mode, double alpha, double beta,
+                            double meanLogProb, int covered, int total) {
+        @Override
+        public String toString() {
+            return String.format(
+                    "%-12s best alpha=%.4f beta=%.4f   mean held-out logP=%9.4f   covered %d/%d (%.1f%%)",
+                    mode, alpha, beta, meanLogProb, covered, total,
+                    100.0 * covered / total);
+        }
+    }
+
+    /* -- SCORING TRACES -- */
+
+    /**
+     * Extracts a scoring trace per test tree from a built CCD graph. A trace is
+     * the list of multi-split-clade {@link Factor}s the tree traverses; it is
+     * {@code null} if the tree is not covered (a clade or split is missing).
+     *
+     * @param ccd       a built (NNI-)regCCD graph (its CCPs are not used)
+     * @param testTrees trees to trace
+     * @return one trace (or null) per test tree
+     */
+    public static List<List<Factor>> extractTraces(AbstractCCD ccd, List<Tree> testTrees) {
+        Map<Clade, int[]> weightCache = new HashMap<>();
+        List<List<Factor>> traces = new ArrayList<>(testTrees.size());
+        for (Tree tree : testTrees) {
+            List<Factor> trace = new ArrayList<>();
+            boolean[] uncovered = {false};
+            extract(tree.getRoot(), ccd, trace, uncovered, weightCache);
+            traces.add(uncovered[0] ? null : trace);
+        }
+        return traces;
+    }
+
+    /* Recursive trace extraction; returns the clade of this vertex or null if missing. */
+    private static Clade extract(Node vertex, AbstractCCD ccd, List<Factor> trace,
+                                 boolean[] uncovered, Map<Clade, int[]> weightCache) {
+        if (uncovered[0]) {
+            return null;
+        }
+        if (vertex.isLeaf()) {
+            BitSet bits = BitSet.newBitSet(ccd.getSizeOfLeavesArray());
+            bits.set(vertex.getNr());
+            Clade leaf = ccd.getClade(bits);
+            if (leaf == null) {
+                uncovered[0] = true;
+            }
+            return leaf;
+        }
+
+        Clade c1 = extract(vertex.getChildren().get(0), ccd, trace, uncovered, weightCache);
+        Clade c2 = extract(vertex.getChildren().get(1), ccd, trace, uncovered, weightCache);
+        if (uncovered[0] || c1 == null || c2 == null) {
+            uncovered[0] = true;
+            return null;
+        }
+
+        BitSet bits = (BitSet) c1.getCladeInBits().clone();
+        bits.or(c2.getCladeInBits());
+        Clade clade = ccd.getClade(bits);
+        if (clade == null) {
+            uncovered[0] = true;
+            return null;
+        }
+        CladePartition partition = clade.getCladePartition(c1, c2);
+        if (partition == null) {
+            uncovered[0] = true;
+            return null;
+        }
+
+        // single-split clades are deterministic (CCP = 1), contributing nothing
+        if (clade.getNumberOfPartitions() > 1) {
+            int[] w = weightCache.computeIfAbsent(clade, NNIRegCCDOptimiser::splitWeights);
+            trace.add(new Factor(partition.getNumberOfOccurrences(),
+                    clade.getNumberOfOccurrences(), w[0], w[1],
+                    CCD1Regularisor.isNNISplit(clade, partition)));
+        }
+        return clade;
+    }
+
+    /* {regular split count, NNI split count} for a clade. */
+    private static int[] splitWeights(Clade clade) {
+        int reg = 0, nni = 0;
+        for (CladePartition partition : clade.getPartitions()) {
+            if (CCD1Regularisor.isNNISplit(clade, partition)) {
+                nni++;
+            } else {
+                reg++;
+            }
+        }
+        return new int[]{reg, nni};
+    }
+
+    /* -- OBJECTIVE -- */
+
+    /** Log probability of one covered tree's trace at the given pseudocounts. */
+    public static double logProb(List<Factor> trace, double alpha, double beta) {
+        double lp = 0.0;
+        for (Factor factor : trace) {
+            lp += factor.logCCP(alpha, beta);
+        }
+        return lp;
+    }
+
+    /** Mean log probability over the covered traces (null traces are skipped). */
+    public static double meanLogProb(List<List<Factor>> traces, double alpha, double beta) {
+        double sum = 0.0;
+        int n = 0;
+        for (List<Factor> trace : traces) {
+            if (trace != null) {
+                sum += logProb(trace, alpha, beta);
+                n++;
+            }
+        }
+        return (n == 0) ? Double.NaN : sum / n;
+    }
+
+    /* -- OPTIMISATION -- */
+
+    /**
+     * Builds the strided CV fold graphs once and extracts a held-out scoring
+     * trace per tree. This is the expensive step; the cheap {@code (alpha, beta)}
+     * grid search then reuses these traces.
+     *
+     * @param trees all trees (post burn-in)
+     * @param folds number of strided CV folds (B)
+     * @param mode  NNI pairing mode
+     * @return one trace (or null if uncovered) per tree
+     */
+    public static List<List<Factor>> buildFoldTraces(List<Tree> trees, int folds, PairingMode mode) {
+        int n = trees.size();
+        List<List<Factor>> allTraces = new ArrayList<>(n);
+        for (int f = 0; f < folds; f++) {
+            List<Tree> train = new ArrayList<>(n);
+            List<Tree> test = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                if (i % folds == f) {
+                    test.add(trees.get(i));
+                } else {
+                    train.add(trees.get(i));
+                }
+            }
+            NNIRegCCD foldModel = new NNIRegCCD(train, 0.0, mode, NNIRegCCD.DEFAULT_ALPHA);
+            allTraces.addAll(extractTraces(foldModel, test));
+            System.out.println("  [" + mode + "] fold " + (f + 1) + "/" + folds + " traced");
+        }
+        return allTraces;
+    }
+
+    /** Grid search for the maximum mean held-out log probability over the traces. */
+    public static OptResult argmax(List<List<Factor>> traces, PairingMode mode,
+                                   double[] alphas, double[] betas) {
+        int covered = 0;
+        for (List<Factor> trace : traces) {
+            if (trace != null) {
+                covered++;
+            }
+        }
+        double bestAlpha = alphas[0], bestBeta = betas[0], best = Double.NEGATIVE_INFINITY;
+        for (double alpha : alphas) {
+            for (double beta : betas) {
+                double mean = meanLogProb(traces, alpha, beta);
+                if (mean > best) {
+                    best = mean;
+                    bestAlpha = alpha;
+                    bestBeta = beta;
+                }
+            }
+        }
+        return new OptResult(mode, bestAlpha, bestBeta, best, covered, traces.size());
+    }
+
+    /**
+     * Builds the strided CV fold graphs once and grid searches {@code (alpha,
+     * beta)} for the maximum mean held-out log probability.
+     *
+     * @param trees  all trees (post burn-in)
+     * @param folds  number of strided CV folds (B)
+     * @param mode   NNI pairing mode
+     * @param alphas alpha grid
+     * @param betas  beta grid
+     * @return the best {@code (alpha, beta)} and its mean held-out log probability
+     */
+    public static OptResult optimise(List<Tree> trees, int folds, PairingMode mode,
+                                     double[] alphas, double[] betas) {
+        return argmax(buildFoldTraces(trees, folds, mode), mode, alphas, betas);
+    }
+
+    private static final double[] DEFAULT_ALPHAS = {0.05, 0.1, 0.2, 0.4, 0.8, 1.6};
+    private static final double[] DEFAULT_BETAS = {0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.4, 0.8};
+
+    /* Warn if an optimum sits on the edge of the search grid (true optimum may lie beyond). */
+    private static void warnIfOnBoundary(OptResult r, double[] alphas, double[] betas) {
+        if (r.alpha() == alphas[0] || r.alpha() == alphas[alphas.length - 1]) {
+            System.out.println("  warning: best alpha at grid boundary (" + r.alpha() + "); widen the grid");
+        }
+        if (r.beta() == betas[0] || r.beta() == betas[betas.length - 1]) {
+            System.out.println("  warning: best beta at grid boundary (" + r.beta() + "); widen the grid");
+        }
+    }
+
+    private static List<Tree> loadTrees(String path, int burninPercentage) throws Exception {
+        TreeAnnotator.MemoryFriendlyTreeSet treeSet = CCDToolUtil.getTreeSet(path, burninPercentage);
+        List<Tree> trees = new ArrayList<>();
+        treeSet.reset();
+        while (treeSet.hasNext()) {
+            trees.add(treeSet.next());
+        }
+        return trees;
+    }
+
+    private static List<PairingMode> parseModes(String sel) {
+        return switch (sel.toLowerCase()) {
+            case "co", "co_occurring" -> List.of(PairingMode.CO_OCCURRING);
+            case "gw", "graph_wide" -> List.of(PairingMode.GRAPH_WIDE);
+            default -> List.of(PairingMode.values());
+        };
+    }
+
+    /* batch <out.csv> <folds> <burnin%> <co|gw|both> <trees...> : optimise each dataset, append a CSV row. */
+    private static void batchMain(String[] args) throws Exception {
+        String out = args[1];
+        int folds = Integer.parseInt(args[2]);
+        int burnin = Integer.parseInt(args[3]);
+        List<PairingMode> modes = parseModes(args[4]);
+
+        File csv = new File(out);
+        boolean writeHeader = !csv.exists() || csv.length() == 0;
+        try (PrintWriter w = new PrintWriter(new FileWriter(csv, true))) {
+            if (writeHeader) {
+                w.println("dataset,taxa,trees,mode,alpha,beta,meanLogProb,covered,total");
+                w.flush();
+            }
+            for (int a = 5; a < args.length; a++) {
+                String path = args[a];
+                String name = new File(path).getName().replaceAll("\\.trees$", "");
+                List<Tree> trees;
+                try {
+                    trees = loadTrees(path, burnin);
+                } catch (Exception e) {
+                    System.out.println("SKIP " + name + " (" + e.getMessage() + ")");
+                    continue;
+                }
+                int taxa = trees.get(0).getLeafNodeCount();
+                System.out.println("=== " + name + " : " + taxa + " taxa, " + trees.size() + " trees ===");
+                for (PairingMode mode : modes) {
+                    OptResult r = optimise(trees, folds, mode, DEFAULT_ALPHAS, DEFAULT_BETAS);
+                    w.printf(Locale.US, "%s,%d,%d,%s,%.4f,%.4f,%.6f,%d,%d%n",
+                            name, taxa, trees.size(), mode, r.alpha(), r.beta(),
+                            r.meanLogProb(), r.covered(), r.total());
+                    w.flush();
+                    System.out.println(r);
+                    warnIfOnBoundary(r, DEFAULT_ALPHAS, DEFAULT_BETAS);
+                }
+            }
+        }
+        System.out.println("Wrote " + out);
+    }
+
+    /* Parse "start:end:step" into an inclusive grid (e.g. "0.15:0.25:0.01" → 11 values). */
+    private static double[] parseGrid(String spec) {
+        String[] parts = spec.split(":");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("grid spec must be start:end:step, got: " + spec);
+        }
+        double start = Double.parseDouble(parts[0]);
+        double end = Double.parseDouble(parts[1]);
+        double step = Double.parseDouble(parts[2]);
+        if (step <= 0 || end < start) {
+            throw new IllegalArgumentException("invalid grid: " + spec);
+        }
+        int n = (int) Math.round((end - start) / step) + 1;
+        double[] grid = new double[n];
+        for (int i = 0; i < n; i++) {
+            grid[i] = start + i * step;
+        }
+        return grid;
+    }
+
+    /* heldout <train> <test> <burnin%> <co|gw|both> <alpha-spec> <beta-spec> : fit on train, score on test. */
+    private static void heldOutMain(String[] args) throws Exception {
+        if (args.length < 7) {
+            System.err.println("Usage: NNIRegCCDOptimiser heldout <train.trees> <test.trees> "
+                    + "<burnin%> <co|gw|both> <alpha-start:end:step> <beta-start:end:step>");
+            System.exit(1);
+        }
+        String trainPath = args[1];
+        String testPath = args[2];
+        int burnin = Integer.parseInt(args[3]);
+        List<PairingMode> modes = parseModes(args[4]);
+        double[] alphas = parseGrid(args[5]);
+        double[] betas = parseGrid(args[6]);
+
+        List<Tree> train = loadTrees(trainPath, burnin);
+        List<Tree> test = loadTrees(testPath, burnin);
+        System.out.printf("train: %d trees (%s), test: %d trees (%s)%n",
+                train.size(), new File(trainPath).getName(),
+                test.size(), new File(testPath).getName());
+        System.out.printf("grid: %d alphas [%g .. %g] × %d betas [%g .. %g] = %d points%n",
+                alphas.length, alphas[0], alphas[alphas.length - 1],
+                betas.length, betas[0], betas[betas.length - 1],
+                alphas.length * betas.length);
+
+        for (PairingMode mode : modes) {
+            System.out.println("building NNIRegCCD[" + mode + "] on training set...");
+            NNIRegCCD model = new NNIRegCCD(train, 0.0, mode, NNIRegCCD.DEFAULT_ALPHA);
+            List<List<Factor>> traces = extractTraces(model, test);
+            OptResult r = argmax(traces, mode, alphas, betas);
+            System.out.println(r);
+            warnIfOnBoundary(r, alphas, betas);
+        }
+    }
+
+    /* surface <out.csv> <trees> <folds> <burnin%> <co|gw> : dump the full (alpha,beta) objective grid. */
+    private static void surfaceMain(String[] args) throws Exception {
+        String out = args[1];
+        int folds = Integer.parseInt(args[3]);
+        int burnin = Integer.parseInt(args[4]);
+        PairingMode mode = parseModes(args[5]).get(0);
+        List<Tree> trees = loadTrees(args[2], burnin);
+        List<List<Factor>> traces = buildFoldTraces(trees, folds, mode);
+        try (PrintWriter w = new PrintWriter(new FileWriter(out))) {
+            w.println("alpha,beta,meanLogProb");
+            for (double alpha : DEFAULT_ALPHAS) {
+                for (double beta : DEFAULT_BETAS) {
+                    w.printf(Locale.US, "%.4f,%.4f,%.6f%n", alpha, beta, meanLogProb(traces, alpha, beta));
+                }
+            }
+        }
+        System.out.println("Wrote surface to " + out);
+    }
+
+    /**
+     * CLI. Forms:
+     * <ul>
+     * <li>{@code <trees> [folds] [burnin%]} --- optimise (alpha, beta) for each
+     * pairing mode on one dataset;</li>
+     * <li>{@code batch <out.csv> <folds> <burnin%> <co|gw|both> <trees...>} ---
+     * optimise each dataset and append a row per (dataset, mode) to a CSV;</li>
+     * <li>{@code surface <out.csv> <trees> <folds> <burnin%> <co|gw>} --- dump the
+     * full (alpha, beta) objective grid for one dataset.</li>
+     * </ul>
+     *
+     * @param args see above
+     * @throws Exception if a tree file cannot be read
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length >= 1 && args[0].equals("batch")) {
+            batchMain(args);
+            return;
+        }
+        if (args.length >= 1 && args[0].equals("surface")) {
+            surfaceMain(args);
+            return;
+        }
+        if (args.length >= 1 && args[0].equals("heldout")) {
+            heldOutMain(args);
+            return;
+        }
+        if (args.length < 1) {
+            System.err.println("Usage: NNIRegCCDOptimiser <trees> [folds] [burnin%]");
+            System.err.println("   or: NNIRegCCDOptimiser batch <out.csv> <folds> <burnin%> <co|gw|both> <trees...>");
+            System.err.println("   or: NNIRegCCDOptimiser surface <out.csv> <trees> <folds> <burnin%> <co|gw>");
+            System.err.println("   or: NNIRegCCDOptimiser heldout <train> <test> <burnin%> <co|gw|both> <alpha-spec> <beta-spec>");
+            System.exit(1);
+        }
+        int folds = (args.length >= 2) ? Integer.parseInt(args[1]) : 20;
+        int burnin = (args.length >= 3) ? Integer.parseInt(args[2]) : 10;
+        List<Tree> trees = loadTrees(args[0], burnin);
+        System.out.println("(alpha,beta) optimisation: " + folds + "-fold strided CV, "
+                + trees.size() + " trees");
+        for (PairingMode mode : PairingMode.values()) {
+            OptResult result = optimise(trees, folds, mode, DEFAULT_ALPHAS, DEFAULT_BETAS);
+            System.out.println(result);
+            warnIfOnBoundary(result, DEFAULT_ALPHAS, DEFAULT_BETAS);
+        }
+    }
+}

--- a/src/main/java/ccd/model/AbstractCCD.java
+++ b/src/main/java/ccd/model/AbstractCCD.java
@@ -133,8 +133,8 @@ public abstract class AbstractCCD implements ITreeDistribution {
         this.burnin = burnin;
         List<Tree> treesToUse;
         if (burnin == 0) {
-            treesToUse = trees;
             this.numBaseTrees = trees.size();
+            treesToUse = trees;
         } else {
             int numDiscardedTrees = (int) (trees.size() * burnin);
             int numUsedTrees = trees.size() - numDiscardedTrees;
@@ -142,7 +142,7 @@ public abstract class AbstractCCD implements ITreeDistribution {
             treesToUse = new ArrayList<Tree>(numUsedTrees);
             treesToUse.addAll(trees.subList(numDiscardedTrees, trees.size()));
         }
-
+        // initializeRootClade(treesToUse.get(0).getLeafNodeCount());
         for (Tree tree : treesToUse) {
             cladifyTree(tree);
         }
@@ -265,7 +265,7 @@ public abstract class AbstractCCD implements ITreeDistribution {
     }
 
     /* Recursive helper method */
-    private Clade cladifyVertex(Node vertex) {
+    protected Clade cladifyVertex(Node vertex) {
         BitSet cladeInBits = BitSet.newBitSet(leafArraySize);
         Clade firstChildClade = null;
         Clade secondChildClade = null;
@@ -314,6 +314,23 @@ public abstract class AbstractCCD implements ITreeDistribution {
     }
 
     /**
+     * Returns the clade for the given BitSet, creating and adding it (with zero
+     * occurrences) if it does not exist yet. Intended for graph-expansion
+     * algorithms that introduce novel clades (e.g. NNI clade expansion); the
+     * given BitSet is cloned so the caller may reuse it.
+     *
+     * @param cladeInBits BitSet describing the clade
+     * @return the existing or newly created clade
+     */
+    public Clade getOrCreateClade(BitSet cladeInBits) {
+        Clade clade = cladeMapping.get(cladeInBits);
+        if (clade == null) {
+            clade = addNewClade((BitSet) cladeInBits.clone());
+        }
+        return clade;
+    }
+
+    /**
      * Removes the given tree from set of trees the CCD graph is based on
      * (reduces the number of occurrences for each of the tree's clades and
      * partitions by one). The behavior is unspecified if tree wasn't used
@@ -340,7 +357,7 @@ public abstract class AbstractCCD implements ITreeDistribution {
     }
 
     /* Recursive helper method */
-    private Clade reduceCladeCount(Node vertex) {
+    protected Clade reduceCladeCount(Node vertex) {
         // 1. build BitSet to retrieve clade and call recursion
         BitSet cladeInBits = BitSet.newBitSet(leafArraySize);
         Clade firstChildClade = null;
@@ -511,6 +528,13 @@ public abstract class AbstractCCD implements ITreeDistribution {
     /* -- GENERAL & CCD GRAPH GETTERS -- */
 
     /**
+     * @return whether the given clade has a sampled ancestor at its root under this CCD model
+     */
+    public boolean isSampledAncestor(Clade clade) {
+        return false; // default AbstractCCD is not a sampled ancestor model
+    }
+
+    /**
      * @return number of leaves/taxa of the trees this CCD is build on (which
      * might be less than the taxa existing in this CCD, namely, if it
      * is filtered)
@@ -538,6 +562,13 @@ public abstract class AbstractCCD implements ITreeDistribution {
         return rootClade;
     }
 
+    /**
+     * Number of clades including leaves and the root.
+     * A sampled ancestor leaf is counted as a different leaf from a normal leaf.
+     * TODO might want to not double count sampled ancestor leaves
+     *
+     * @return number of clades
+     */
     @Override
     public int getNumberOfClades() {
         return cladeMapping.size();
@@ -721,7 +752,6 @@ public abstract class AbstractCCD implements ITreeDistribution {
                 testro += partition.getProbability() * logS;
             }
         }
-
         return -testro;
     }
 
@@ -877,7 +907,7 @@ public abstract class AbstractCCD implements ITreeDistribution {
     }
 
     /* Recursive helper method */
-    private Node getVertexBasedOnStrategy(Clade clade, SamplingStrategy samplingStrategy, HeightSettingStrategy heightStrategy) {
+    protected Node getVertexBasedOnStrategy(Clade clade, SamplingStrategy samplingStrategy, HeightSettingStrategy heightStrategy) {
         // computeCladeProbabilitiesIfDirty();
 
         Node vertex = null;
@@ -906,70 +936,95 @@ public abstract class AbstractCCD implements ITreeDistribution {
             Node secondChild = getVertexBasedOnStrategy(partition.getChildClades()[1],
                     samplingStrategy, heightStrategy);
 
-            // These are not needed and only make the output newick longer
-            vertex = new Node();
-            vertex.setNr(runningInnerIndex++);
-            double cladeProbability = clade.getProbability();
-            vertex.setMetaData(CLADE_SUPPORT_KEY, cladeProbability);
-            String posteriorSupport = CLADE_SUPPORT_KEY + "=" + cladeProbability;
-            if (vertex.metaDataString != null) {
-                vertex.metaDataString += "," + posteriorSupport;
-            } else {
-                vertex.metaDataString = posteriorSupport;
+            vertex = buildInternalVertex(clade, partition, firstChild, secondChild, heightStrategy);
+        }
+
+        return vertex;
+    }
+
+    /**
+     * Builds an internal (non-leaf) vertex for the two already-constructed child subtrees of
+     * the given {@code clade}, resolved through {@code partition}. Assigns the next inner-node
+     * number, attaches clade-support and (log-)subtree-probability metadata, and sets the height
+     * per the {@link HeightSettingStrategy}. Factored out of {@link #getVertexBasedOnStrategy}
+     * so subclasses (e.g. {@code KRegCCD}) can reuse the exact same observed-split construction
+     * while overriding the recursion.
+     */
+    protected Node buildInternalVertex(Clade clade, CladePartition partition,
+                                       Node firstChild, Node secondChild,
+                                       HeightSettingStrategy heightStrategy) {
+        // These are not needed and only make the output newick longer
+        Node vertex = new Node();
+        vertex.setNr(nextRunningInnerIndex());
+        double cladeProbability = clade.getProbability();
+        vertex.setMetaData(CLADE_SUPPORT_KEY, cladeProbability);
+        String posteriorSupport = CLADE_SUPPORT_KEY + "=" + cladeProbability;
+        if (vertex.metaDataString != null) {
+            vertex.metaDataString += "," + posteriorSupport;
+        } else {
+            vertex.metaDataString = posteriorSupport;
+        }
+        vertex.addChild(firstChild);
+        vertex.addChild(secondChild);
+
+        // attach probability information
+        Double p = (Double) firstChild.getMetaData(PROB_SUBTREE_KEY)
+                * (Double) secondChild.getMetaData(PROB_SUBTREE_KEY)
+                * partition.getCCP();
+        Double logP = (Double) firstChild.getMetaData(LOG_PROB_SUBTREE_KEY)
+                + (Double) secondChild.getMetaData(LOG_PROB_SUBTREE_KEY)
+                + partition.getLogCCP();
+        vertex.setMetaData(PROB_SUBTREE_KEY, p);
+        vertex.setMetaData(LOG_PROB_SUBTREE_KEY, logP);
+
+        if (heightStrategy == HeightSettingStrategy.MeanOccurredHeights) {
+            vertex.setHeight(clade.getMeanOccurredHeight());
+        } else if (heightStrategy == HeightSettingStrategy.One) {
+            vertex.setHeight(computeParentHeight(partition, firstChild, secondChild));
+        } else if (heightStrategy == HeightSettingStrategy.CommonAncestorHeights) {
+            // out.println("\nvertex = " + vertex);
+            // out.println("vertex.getHeight() = " + vertex.getHeight());
+            // out.println("clade.getCommonAncestorHeight() = " + clade.getCommonAncestorHeight());
+            vertex.setHeight(clade.getCommonAncestorHeight());
+            // out.println("vertex.getHeight() = " + vertex.getHeight());
+
+            if (Double.isNaN(clade.getCommonAncestorHeight())) {
+                System.err.println("\nNaN height!");
+                System.err.println("clade = " + clade);
+                System.err.println("clade.getCommonAncestorHeight() = " + clade.getCommonAncestorHeight());
             }
-            vertex.addChild(firstChild);
-            vertex.addChild(secondChild);
 
-            // attach probability information
-            Double p = (Double) firstChild.getMetaData(PROB_SUBTREE_KEY)
-                    * (Double) secondChild.getMetaData(PROB_SUBTREE_KEY)
-                    * partition.getCCP();
-            Double logP = (Double) firstChild.getMetaData(LOG_PROB_SUBTREE_KEY)
-                    + (Double) secondChild.getMetaData(LOG_PROB_SUBTREE_KEY)
-                    + partition.getLogCCP();
-            vertex.setMetaData(PROB_SUBTREE_KEY, p);
-            vertex.setMetaData(LOG_PROB_SUBTREE_KEY, logP);
-
-            if (heightStrategy == HeightSettingStrategy.MeanOccurredHeights) {
-                vertex.setHeight(clade.getMeanOccurredHeight());
-            } else if (heightStrategy == HeightSettingStrategy.One) {
-                double height = Math.max(firstChild.getHeight(), secondChild.getHeight()) + 1;
-                vertex.setHeight(height);
-            } else if (heightStrategy == HeightSettingStrategy.CommonAncestorHeights) {
-                // out.println("\nvertex = " + vertex);
-                // out.println("vertex.getHeight() = " + vertex.getHeight());
-                // out.println("clade.getCommonAncestorHeight() = " + clade.getCommonAncestorHeight());
-                vertex.setHeight(clade.getCommonAncestorHeight());
-                // out.println("vertex.getHeight() = " + vertex.getHeight());
-
-                if (Double.isNaN(clade.getCommonAncestorHeight())) {
-                    System.err.println("\nNaN height!");
-                    System.err.println("clade = " + clade);
-                    System.err.println("clade.getCommonAncestorHeight() = " + clade.getCommonAncestorHeight());
-                }
-
-                if (vertex.getHeight() < 0) {
-                    System.err.println("\nVertex with negative height");
-                    System.err.println("vertex.getHeight() = " + vertex.getHeight());
-                    System.err.println("clade.getCommonAncestorHeight =  " + clade.getCommonAncestorHeight());
-                    System.err.println("clade.getMeanOccurredHeight =  " + clade.getMeanOccurredHeight());
-                }
-                if ((vertex.getHeight() - vertex.getLeft().getHeight()) < 0) {
-                    System.err.println("\nNegative branch length, L");
-                    System.err.println("branchLength = " + (vertex.getHeight() - vertex.getLeft().getHeight()));
-                    System.err.println("parent = " + vertex);
-                    System.err.println("childL = " + vertex.getLeft());
-                }
-                if ((vertex.getHeight() - vertex.getRight().getHeight()) < 0) {
-                    System.err.println("\nNegative branch length, R");
-                    System.err.println("branchLength = " + (vertex.getHeight() - vertex.getLeft().getHeight()));
-                    System.err.println("parent = " + vertex);
-                    System.err.println("childR = " + vertex.getRight());
-                }
+            if (vertex.getHeight() < 0) {
+                System.err.println("\nVertex with negative height");
+                System.err.println("vertex.getHeight() = " + vertex.getHeight());
+                System.err.println("clade.getCommonAncestorHeight =  " + clade.getCommonAncestorHeight());
+                System.err.println("clade.getMeanOccurredHeight =  " + clade.getMeanOccurredHeight());
+            }
+            if ((vertex.getHeight() - vertex.getLeft().getHeight()) < 0) {
+                System.err.println("\nNegative branch length, L");
+                System.err.println("branchLength = " + (vertex.getHeight() - vertex.getLeft().getHeight()));
+                System.err.println("parent = " + vertex);
+                System.err.println("childL = " + vertex.getLeft());
+            }
+            if ((vertex.getHeight() - vertex.getRight().getHeight()) < 0) {
+                System.err.println("\nNegative branch length, R");
+                System.err.println("branchLength = " + (vertex.getHeight() - vertex.getLeft().getHeight()));
+                System.err.println("parent = " + vertex);
+                System.err.println("childR = " + vertex.getRight());
             }
         }
 
         return vertex;
+    }
+
+    /** Returns and advances the running inner-node index used when materialising sampled trees. */
+    protected int nextRunningInnerIndex() {
+        return runningInnerIndex++;
+    }
+
+    /* Helper method */
+    protected double computeParentHeight(CladePartition partition, Node firstChild, Node secondChild) {
+        return Math.max(firstChild.getHeight(), secondChild.getHeight()) + 1.0;
     }
 
     @Override
@@ -999,12 +1054,11 @@ public abstract class AbstractCCD implements ITreeDistribution {
     public double getMaxLogTreeProbability() {
         tidyUpCacheIfDirty();
         resetCacheIfProbabilitiesDirty();
-
         return this.rootClade.getMaxSubtreeLogCCP();
     }
 
     /* Helper method */
-    private CladePartition getPartitionBasedOnStrategy(Clade clade, SamplingStrategy samplingStrategy) {
+    protected CladePartition getPartitionBasedOnStrategy(Clade clade, SamplingStrategy samplingStrategy) {
         CladePartition partition = null;
         switch (samplingStrategy) {
             case MAP: {
@@ -1228,7 +1282,7 @@ public abstract class AbstractCCD implements ITreeDistribution {
     }
 
     /* Helper method */
-    private BitSet computeCladeToNodeMapping(Node vertex, Map<Clade, Node> map) {
+    protected BitSet computeCladeToNodeMapping(Node vertex, Map<Clade, Node> map) {
         BitSet bits;
         if (vertex.isLeaf()) {
             bits = BitSet.newBitSet(getSizeOfLeavesArray());
@@ -1247,7 +1301,6 @@ public abstract class AbstractCCD implements ITreeDistribution {
 
         return bits;
     }
-
 
     /* -- PROBABILITY - PROBABILITY -- */
     protected void setToUseLogProbabilities() {
@@ -1284,7 +1337,7 @@ public abstract class AbstractCCD implements ITreeDistribution {
     }
 
     /* Recursive helper method */
-    private Clade computeProbabilityOfVertex(Node vertex, double[] runningProbability, boolean computeLog) {
+    protected Clade computeProbabilityOfVertex(Node vertex, double[] runningProbability, boolean computeLog) {
         BitSet cladeInBits = BitSet.newBitSet(leafArraySize);
 
         if (vertex.isLeaf()) {
@@ -1534,13 +1587,13 @@ public abstract class AbstractCCD implements ITreeDistribution {
     /*-- DISTANCES - DISTANCES -- */
 
     /**
-     * Returns the expected RF distance of the given tree to the trees of this
+     * Returns the average RF distance of the given tree to the trees of this
      * CCD weighted by their probability.
      *
      * @param tree whose average RF distance we compute
      * @return average RF distance of the given tree to this CCD
      */
-    public double expectedRFDistances(Tree tree) {
+    public double averageRFDistances(Tree tree) {
         WrappedBeastTree wrappedTree = new WrappedBeastTree(tree);
         HashMap<Clade, Double> cladeRFs = new HashMap<Clade, Double>(this.cladeMapping.size());
         return averageRFDistance(this.rootClade, wrappedTree, cladeRFs);
@@ -1689,6 +1742,10 @@ public abstract class AbstractCCD implements ITreeDistribution {
         return "[number of leaves: " + this.getNumberOfLeaves() + ", number of clades: "
                 + this.getNumberOfClades() + ", max probability: " + this.getMaxTreeProbability()
                 + ", entropy: " + this.getEntropy() + ", taxa: " + this.getTaxaAsBitSet() + "]";
+    }
+
+    protected String getSampledAncestorInfoString(Clade clade) {
+        return "sampled ancestor = none";  // default: no sampled ancestor
     }
 
     public abstract void initialize();

--- a/src/main/java/ccd/model/CCD0.java
+++ b/src/main/java/ccd/model/CCD0.java
@@ -47,7 +47,7 @@ public class CCD0 extends AbstractCCD {
     public static final boolean USE_CLADE_PARAMETERS = true;
 
     /** Whether expand should use the monophyletic clade speedup. */
-    private boolean useMonophyleticCladeSpeedup = false;
+    protected boolean useMonophyleticCladeSpeedup = false;
 
     /** Whether expand should run update online (instead of from scratch). */
     private boolean updateOnline = false;
@@ -62,7 +62,7 @@ public class CCD0 extends AbstractCCD {
     private List<Clade> newClades = null;
 
     /** Clades organized by size for more efficient expand method. */
-    private List<List<Clade>> cladeBuckets = null;
+    protected List<List<Clade>> cladeBuckets = null;
 
     /**
      * from[i][j] is the first clade in cladeBuckets[i] that has bit j set.
@@ -73,10 +73,10 @@ public class CCD0 extends AbstractCCD {
      * All others have at least one taxon outside C: the clades below from[i][]
      * have a taxon below any taxon in C and the clades above to[i][] have one above.
      */
-    private int[][] from, to;
+    protected int[][] from, to;
 
     /** Clades already processed */
-    private Set<Clade> done;
+    protected Set<Clade> done;
 
     /** Stream to report on progress of CCD0 construction. */
     private PrintStream progressStream = System.out;
@@ -96,7 +96,7 @@ public class CCD0 extends AbstractCCD {
     public static final int NUM_CLADES_PARALLELIZATION_THRESHOLD = 20000;
 
     /** Number of worker threads used for the expand step. */
-    private int threadCount = 1;
+    protected int threadCount = 1;
     private CountDownLatch countDown = null;
 
 
@@ -397,7 +397,7 @@ public class CCD0 extends AbstractCCD {
 
         // 3. clade buckets
         // for easier matching of child clades, we want to group them by size
-        cladeBuckets = processCladeBuckets(clades, leafArraySize);
+        cladeBuckets = processCladeBuckets(clades);
 
         // 4. find missing clade partitions
         done = new HashSet<>();
@@ -439,18 +439,16 @@ public class CCD0 extends AbstractCCD {
         // System.err.println("Expanded in " + (end-start) + " ms");
     }
 
-
     /**
      * set up clade buckets so that
      * 1. each bucket contains clades of the same size
      * 2. clades are sorted by first set bit, then last set bit
      * 3. as a side effect, the from[][] and to[][] arrays are initialised
      *
-     * @param clades        set of clades to distribute into clade buckets
-     * @param leafArraySize = maximum clade size
+     * @param clades set of clades to distribute into clade buckets
      * @return clade buckets
      */
-    private List<List<Clade>> processCladeBuckets(List<Clade> clades, int leafArraySize) {
+    protected List<List<Clade>> processCladeBuckets(List<Clade> clades) {
         List<List<Clade>> cladeBuckets = new ArrayList<>(leafArraySize);
 
         // 3.i init clade buckets
@@ -496,9 +494,9 @@ public class CCD0 extends AbstractCCD {
                         fromi[j++] = c;
                     }
                     int max = clade.getCladeInBits().lastSetBit();
-//	        		if (max < 0 || max >= toi.length) {
-//	        			max = clade.getCladeInBits().lastSetBit();
-//	        		}
+                    //	        		if (max < 0 || max >= toi.length) {
+                    //	        			max = clade.getCladeInBits().lastSetBit();
+                    //	        		}
                     toi[max] = c;
                 }
                 while (j < leafArraySize) {
@@ -580,7 +578,7 @@ public class CCD0 extends AbstractCCD {
     }
 
     /* Helper method - do the work for one particular clade */
-    private void findChildPartitionsOf(Clade parent, BitSet helperBits) {
+    protected void findChildPartitionsOf(Clade parent, BitSet helperBits) {
         // we skip leaves and cherries as they have no/only one partition
         if (parent.isLeaf() || parent.isCherry()) {
             return;
@@ -666,7 +664,7 @@ public class CCD0 extends AbstractCCD {
     }
 
     /* Helper method */
-    private void findPartitionHelper(Clade child, Clade parent, BitSet helperBits, BitSet parentBits, BitSet childBits) {
+    protected void findPartitionHelper(Clade child, Clade parent, BitSet helperBits, BitSet parentBits, BitSet childBits) {
         // check whether child clade is contained in parent clade
         helperBits.clear();
         helperBits.or(parentBits);
@@ -730,7 +728,7 @@ public class CCD0 extends AbstractCCD {
     /**
      * Recursively computes, sets, and returns the log probabilities of all clade partitions based on the clade credibilities.
      * Method only needs to be called when a CCD0 was constructed manually,
-     * e.g. by the {@link  ccp.algorithms.CCDCombiner}.
+     * e.g. by the {@link  ccd.algorithms.CCDCombiner}.
      *
      * @param clade for which the clade partition probabilities are computed
      * @return the sum of this clade's partitions probabilities times its own credibility
@@ -811,7 +809,7 @@ public class CCD0 extends AbstractCCD {
      * @param clade for which the clade partition probabilities are computed
      * @return the sum of this clade's partitions probabilities times its own credibility
      */
-    public static void setPartitionProbabilities(Clade clade) {
+    public void setPartitionProbabilities(Clade clade) {
         setPartitionProbabilities(clade, !USE_CLADE_PARAMETERS);
     }
 
@@ -824,7 +822,7 @@ public class CCD0 extends AbstractCCD {
      * @param useCladeParameters whether to use the clade parameters or the clade credibilities
      * @return the sum of this clade's partitions probabilities times its own credibility
      */
-    public static double setPartitionProbabilities(Clade clade, boolean useCladeParameters) {
+    public double setPartitionProbabilities(Clade clade, boolean useCladeParameters) {
         if (clade.getSumCladeCredibilities() > 0) {
             return clade.getSumCladeCredibilities();
         }
@@ -886,14 +884,14 @@ public class CCD0 extends AbstractCCD {
                     i++;
                 }
 
-                // log sum = log pMax - log( sum exp(log pi - logMax))
+                // log(Σ exp(xᵢ)) = max + log(Σ exp(xᵢ - max))
                 double intermSum = 0;
                 for (int j = 0; j < logProbs.length; j++) {
                     if (Double.isFinite(logProbs[j])) {
                         intermSum += Math.exp(logProbs[j] - logMax);
                     }
                 }
-                double logSum = logMax - Math.log(intermSum);
+                double logSum = logMax + Math.log(intermSum);
 
                 // normalizing with normalized log pi = log pi - log sum
                 i = 0;

--- a/src/main/java/ccd/model/CCD0CP.java
+++ b/src/main/java/ccd/model/CCD0CP.java
@@ -1,0 +1,224 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.model.bitsets.BitSet;
+
+import java.util.*;
+
+public class CCD0CP extends CCD0 {
+
+    public CCD0CP(List<Tree> trees, double burnin) {
+        super(trees, burnin);
+    }
+
+    public CCD0CP(TreeAnnotator.TreeSet treeSet) {
+        super(treeSet);
+    }
+
+    public CCD0CP(TreeAnnotator.TreeSet treeSet, int numTreesToUse) {
+        super(treeSet, numTreesToUse);
+    }
+
+    public CCD0CP(TreeAnnotator.TreeSet treeSet, boolean storeBaseTrees) {
+        super(treeSet, storeBaseTrees);
+    }
+
+    public CCD0CP(int numLeaves, boolean storeBaseTrees) {
+        super(numLeaves, storeBaseTrees);
+    }
+
+    /* -- ROOT INITIALIZATION -- */
+    @Override
+    protected void initializeRootClade(int numLeaves) {
+        CPSupport.initializeRoot(this, numLeaves);
+    }
+
+    @Override
+    protected Clade cladifyVertex(Node vertex) {
+        return CPSupport.cladifyVertex(this, vertex);
+    }
+
+    @Override
+    public boolean isSampledAncestor(Clade clade) {
+        return CPSupport.isSampledAncestor(clade, leafArraySize);
+    }
+
+    @Override
+    protected String getSampledAncestorInfoString(Clade clade) {
+        return CPSupport.saInfoString(clade, leafArraySize);
+    }
+
+    @Override
+    protected double computeParentHeight(CladePartition partition, Node firstChild, Node secondChild) {
+        return CPSupport.computeParentHeight(partition, firstChild, secondChild, leafArraySize);
+    }
+
+    @Override
+    protected void expand() {
+        List<Clade> realClades = new ArrayList<>();
+        Map<BitSet, List<Clade>> taxaMaskToClades = new HashMap<>();
+        for (Clade c : cladeMapping.values()) {
+            realClades.add(c);
+            BitSet taxaMask = c.getCladeInBitsTaxaOnly();
+            taxaMaskToClades.computeIfAbsent(taxaMask, k -> new ArrayList<>()).add(c);
+        }
+
+        int n = realClades.size();
+        for (int i = 0; i < n; i++) {
+            Clade A = realClades.get(i);
+            BitSet taxaA = A.getCladeInBitsTaxaOnly();
+            for (int j = i + 1; j < n; j++) {
+                Clade B = realClades.get(j);
+                BitSet taxaB = B.getCladeInBitsTaxaOnly();
+
+                // Taxa-disjointness check via base mask.
+                if (taxaA.intersects(taxaB)) continue;
+
+                // Compute taxa union and look up all parent clades sharing
+                // that taxa-mask (any number of SA variants).
+                BitSet unionMask = (BitSet) taxaA.clone();
+                unionMask.or(taxaB);
+
+                List<Clade> parents = taxaMaskToClades.get(unionMask);
+                if (parents == null) continue;
+
+                for (Clade parent : parents) {
+                    if (parent == A || parent == B) continue;
+                    if (parent.size() == 2) {
+                        // cannot have a cherry with both children being SA
+                        if (isSampledAncestor(A) && isSampledAncestor(B)) continue;
+                    }
+                    if (parent.getCladePartition(A, B) != null) continue;
+                    parent.createCladePartition(A, B);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Clade computeProbabilityOfVertex(Node vertex, double[] runningProbability, boolean computeLog) {
+        return CPSupport.computeProbCPVertex(vertex, runningProbability, computeLog, this, leafArraySize);
+    }
+
+    @Override
+    public double setPartitionProbabilities(Clade clade, boolean useCladeParameters) {
+
+        // usually initialise CCD0 uses getCladeCredibility
+        double cladeValue = useCladeParameters ? clade.getCladeParameter() : clade.getCladeCredibility();
+
+        if (clade.isLeaf()) {
+            // Leaves carry cladeValue (their extended-clade credibility), NOT 1, so the
+            // leaf branch must run BEFORE the memo guard: resetSumCladeCredibilities sets
+            // leaves to 1, which the guard would otherwise return as a stale CCP.
+            clade.setSumCladeCredibilities(cladeValue);
+            return cladeValue;
+        } else {
+            // Memoise internal clades: the clade DAG has heavy shared substructure, so
+            // without this each clade is recomputed once per path that reaches it
+            // (exponential). Sentinel -1 = not computed this pass
+            // (Clade.resetSumCladeCredibilities sets internal clades to -1).
+            if (clade.getSumCladeCredibilities() >= 0) {
+                return clade.getSumCladeCredibilities();
+            }
+            double sumSubtreeProbabilities = 0.0;
+            double[] sumPartitionSubtreeProbabilities = new double[clade.getPartitions().size()];
+
+            // compute sum of probabilities over all partitions ...
+            int i = 0;
+            for (CladePartition partition : clade.getPartitions()) {
+                sumPartitionSubtreeProbabilities[i] =
+                        setPartitionProbabilities(partition.getChildClades()[0], useCladeParameters)
+                                * setPartitionProbabilities(partition.getChildClades()[1], useCladeParameters);
+                sumSubtreeProbabilities += sumPartitionSubtreeProbabilities[i];
+                i++;
+            }
+
+            // ... and then normalize
+            if (sumSubtreeProbabilities == 0) {
+                // probability of this subtree is so small, that we have an underflow problem;
+                // we can try to use log transformed probabilities to set CCPs
+                // but the probability of the clade will still become zero
+
+                // try log-sum-exp trick
+                double logMax = Double.NEGATIVE_INFINITY;
+                double[] logProbs = new double[clade.getPartitions().size()];
+                i = 0;
+                for (CladePartition partition : clade.getPartitions()) {
+                    double left = partition.getChildClades()[0].getSumCladeCredibilities();
+                    double right = partition.getChildClades()[1].getSumCladeCredibilities();
+                    logProbs[i] = Math.log(left) + Math.log(right);
+                    logMax = Math.max(logProbs[i], logMax);
+                    i++;
+                }
+
+                // log(Σ exp(xᵢ)) = max + log(Σ exp(xᵢ - max))
+                double intermSum = 0;
+                for (int j = 0; j < logProbs.length; j++) {
+                    if (Double.isFinite(logProbs[j])) {
+                        intermSum += Math.exp(logProbs[j] - logMax);
+                    }
+                }
+                double logSum = logMax + Math.log(intermSum);
+
+                // normalizing with normalized log pi = log pi - log sum
+                i = 0;
+                double pSum = 0;
+                for (CladePartition partition : clade.getPartitions()) {
+                    if (!Double.isFinite(logProbs[i])) {
+                        // we are still encountering underflows
+                        throw new UnderflowException("An underflow has occurred.");
+                    } else {
+                        double logProbability = logProbs[i] - logSum;
+                        double probability = Math.exp(logProbability);
+                        pSum += probability;
+
+                        if (Double.isNaN(probability)) {
+                            out.println("NaN probability = " + probability);
+                            out.println("logProbability = " + logProbability);
+                            out.println("logProbs[i] = " + logProbs[i]);
+                            out.println("logSum = " + logSum);
+                        }
+
+                        partition.setCCP(probability);
+                    }
+                    i++;
+                }
+            } else {
+                i = 0;
+                for (CladePartition partition : clade.getPartitions()) {
+                    double probability = sumPartitionSubtreeProbabilities[i] / sumSubtreeProbabilities;
+                    if (Double.isNaN(probability)) {
+                        out.println("clade = " + clade);
+                        out.println("partition = " + partition);
+                        out.println("sumPartitionSubtreeProbabilities = " + sumPartitionSubtreeProbabilities[i]);
+                        out.println("sumSubtreeProbabilities = " + sumSubtreeProbabilities);
+                    }
+                    partition.setCCP(probability);
+                    i++;
+                }
+            }
+
+            // combined with probability of clade, we get sum of all subtree probabilities
+            double sumCladeCredibilities = sumSubtreeProbabilities * cladeValue;
+            clade.setSumCladeCredibilities(sumCladeCredibilities);
+            return sumCladeCredibilities;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "CCD0-CP " + super.toString().replaceFirst("CCD0 ", "");
+    }
+
+    @Override
+    public AbstractCCD copy() {
+        CCD0CP copy = new CCD0CP(this.getSizeOfLeavesArray(), false);
+        copy.baseTrees.add(this.getSomeBaseTree());
+        copy.numBaseTrees = this.getNumberOfBaseTrees();
+        AbstractCCD.buildCopy(this, copy);
+        return copy;
+    }
+
+}

--- a/src/main/java/ccd/model/CCD0SJ.java
+++ b/src/main/java/ccd/model/CCD0SJ.java
@@ -1,0 +1,234 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator.TreeSet;
+import ccd.model.bitsets.BitSet;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * CCD0 normalisation on the extended-split (SJ) clade identity for
+ * sampled-ancestor trees. The CCD0-normalised companion to {@link CCD1SJ}:
+ * same identity, but partition probabilities are derived from clade
+ * frequencies via the expand-and-normalise step (CCD0), instead of from
+ * observed split counts alone (CCD1).
+ *
+ * <p>Identity construction, key layout, sampling, MAP selection, and tree
+ * probability traversal are shared with {@link CCD1SJ} via
+ * {@link SJSupport}; see that class for the SJ identity definition. What's
+ * specific to CCD0SJ:
+ *
+ * <h3>Tree probability</h3>
+ *
+ * <p>{@code P(T)} is the product of normalised CCPs along the tree path
+ * (under the SJ identity), folding in the placeholder root's
+ * {@code (variant, emptyClade)} CCP at the top. CCPs come from CCD0's
+ * expand-and-normalise step run on the SJ extended-clade graph: for each
+ * clade {@code C}, the CCP of partition {@code (A, B)} is proportional to
+ * the product of subtree clade-credibility masses of {@code A} and
+ * {@code B}, normalised across all partitions on {@code C}. With expansion
+ * (see {@link #expand()}), the support extends beyond the observed sample
+ * to trees the model considers consistent with the observed clade
+ * frequencies and the SA-flag constraints.
+ *
+ * <h3>Empty sister as a neutral element</h3>
+ *
+ * <p>Under CCD0 normalisation each clade contributes a subtree mass during
+ * recursion. The shared empty sister has no taxa and no partitions, so we
+ * pre-set its sumCladeCredibilities to 1 in {@link #initializeRootClade}
+ * and short-circuit its handling in
+ * {@link #setPartitionProbabilities(Clade, boolean)}. This makes a
+ * placeholder-root partition {@code (variant, empty)} score equal to the
+ * variant's own subtree mass, so root variants compete cleanly under one
+ * normalisation.
+ *
+ * <h3>Expand step</h3>
+ *
+ * <p>The CCD0 expand step is overridden ({@link #expand()}) for two
+ * reasons: (1) it must operate on taxa-only bitmasks for disjointness/union
+ * checks, since the SA flags otherwise spill out of the size-n bucket
+ * arrays in {@link CCD0#expand()}, and (2) it enforces SJ-flag
+ * compatibility on registered partitions
+ * ({@link SJSupport#isSJCompatible}), so the model never assigns
+ * probability to trees that violate the parent's SA-flag identity.
+ */
+public class CCD0SJ extends CCD0 {
+
+    /**
+     * Shared empty sister used in rootClade's (variant, emptyClade) partitions.
+     * Populated in {@link #initializeRootClade} since the super constructor
+     * calls cladifyTree before subclass field initialisers run.
+     */
+    protected Clade emptyClade;
+
+    public CCD0SJ(List<Tree> trees, double burnin) {
+        super(trees, burnin);
+    }
+
+    public CCD0SJ(TreeSet treeSet) {
+        super(treeSet);
+    }
+
+    public CCD0SJ(TreeSet treeSet, int numTreesToUse) {
+        super(treeSet, numTreesToUse);
+    }
+
+    public CCD0SJ(TreeSet treeSet, boolean storeBaseTrees) {
+        super(treeSet, storeBaseTrees);
+    }
+
+    public CCD0SJ(int numLeaves, boolean storeBaseTrees) {
+        super(numLeaves, storeBaseTrees);
+    }
+
+    /* -- ROOT INITIALISATION -- */
+
+    @Override
+    protected void initializeRootClade(int numLeaves) {
+        this.emptyClade = SJSupport.initializeSJRoot(this, numLeaves);
+        // CCD0's recursive setPartitionProbabilities short-circuits on a
+        // positive sumCladeCredibilities, so seed the empty sister with the
+        // neutral value 1.0 before the first call.
+        this.emptyClade.setSumCladeCredibilities(1.0);
+    }
+
+    /* -- TREE INSERTION -- */
+
+    @Override
+    protected Clade cladifyVertex(Node vertex) {
+        return SJSupport.cladifyTreeRoot(this, emptyClade, vertex);
+    }
+
+    /* -- SA DETECTION & DISPLAY -- */
+
+    @Override
+    public boolean isSampledAncestor(Clade clade) {
+        return SJSupport.isSampledAncestor(clade, leafArraySize);
+    }
+
+    @Override
+    protected String getSampledAncestorInfoString(Clade clade) {
+        return SJSupport.saInfoString(clade, leafArraySize);
+    }
+
+    /* -- EXPAND -- */
+
+    /**
+     * Adds clade partitions where parent and children clades were observed
+     * but the partition itself was not. Operates on taxa-only bitmasks for
+     * disjointness/union checks (so the SA-augmented bitset width does not
+     * break the size-n bucket arrays in {@link CCD0#expand()}). A discovered
+     * partition (A, B) is registered on every SA-variant of the parent
+     * clade sharing that base mask whose SA flags are compatible with the
+     * partition (see {@link SJSupport#isSJCompatible}).
+     *
+     * <p>The placeholder {@code rootClade} (size 0, sentinel bit set) and
+     * the shared {@code emptyClade} are skipped: the placeholder root only
+     * ever carries (variant, emptyClade) partitions added during
+     * cladification, and normalisation across variants is handled by
+     * {@link CCD0#setPartitionProbabilities(Clade, boolean)}.
+     */
+    @Override
+    protected void expand() {
+        // Collect non-trivial real clades (skip placeholder root, empty,
+        // leaves, cherries — the latter two have no expandable partitions).
+        List<Clade> realClades = new ArrayList<>();
+        Map<BitSet, List<Clade>> taxaMaskToClades = new HashMap<>();
+        for (Clade c : cladeMapping.values()) {
+            if (c == rootClade || c == emptyClade) continue;
+            realClades.add(c);
+            BitSet taxaMask = c.getCladeInBitsTaxaOnly();
+            taxaMaskToClades.computeIfAbsent(taxaMask, k -> new ArrayList<>()).add(c);
+        }
+
+        int n = realClades.size();
+        for (int i = 0; i < n; i++) {
+            Clade A = realClades.get(i);
+            BitSet taxaA = A.getCladeInBitsTaxaOnly();
+            for (int j = i + 1; j < n; j++) {
+                Clade B = realClades.get(j);
+                BitSet taxaB = B.getCladeInBitsTaxaOnly();
+
+                // Taxa-disjointness check via base mask.
+                if (taxaA.intersects(taxaB)) continue;
+
+                // Compute taxa union and look up all parent clades sharing
+                // that taxa-mask (any number of SA variants).
+                BitSet unionMask = (BitSet) taxaA.clone();
+                unionMask.or(taxaB);
+
+                List<Clade> parents = taxaMaskToClades.get(unionMask);
+                if (parents == null) continue;
+
+                for (Clade parent : parents) {
+                    if (parent == A || parent == B) continue;
+                    if (parent.size() <= 2) continue; // cherries already complete
+                    if (parent.getCladePartition(A, B) != null) continue;
+                    if (!SJSupport.isSJCompatible(parent, A, B, leafArraySize)) continue;
+                    parent.createCladePartition(A, B);
+                }
+            }
+        }
+    }
+
+    /* -- PROBABILITY (CCD0 normalisation) -- */
+
+    /**
+     * Short-circuits the empty sister to a neutral 1.0 so CCD0's recursion
+     * does not stumble over a clade with size 0 and no partitions; otherwise
+     * delegates to CCD0's frequency-based normalisation.
+     */
+    @Override
+    public double setPartitionProbabilities(Clade clade, boolean useCladeParameters) {
+        if (clade == emptyClade) {
+            clade.setSumCladeCredibilities(1.0);
+            return 1.0;
+        }
+        return super.setPartitionProbabilities(clade, useCladeParameters);
+    }
+
+    /* -- TREE PROBABILITY -- */
+
+    @Override
+    protected Clade computeProbabilityOfVertex(Node vertex, double[] runningProbability, boolean computeLog) {
+        return SJSupport.computeTreeProbability(this, emptyClade, vertex, runningProbability, computeLog);
+    }
+
+    /* -- SAMPLING & MAP -- */
+
+    /**
+     * Builds a tree under the SJ identity. The {@code heightStrategy}
+     * argument is currently ignored — see
+     * {@link SJSupport#buildTree(AbstractCCD, Clade, SamplingStrategy, HeightSettingStrategy)}
+     * for the TODO and the reason.
+     */
+    @Override
+    protected Tree getTreeBasedOnStrategy(SamplingStrategy samplingStrategy,
+                                          HeightSettingStrategy heightStrategy) {
+        return SJSupport.buildTree(this, emptyClade, samplingStrategy, heightStrategy);
+    }
+    
+    /* -- MISC -- */
+
+    @Override
+    public String toString() {
+        return "CCD0-SJ " + super.toString().replaceFirst("CCD0 ", "");
+    }
+
+    @Override
+    public AbstractCCD copy() {
+        CCD0SJ copy = new CCD0SJ(this.getSizeOfLeavesArray(), false);
+        copy.baseTrees.add(this.getSomeBaseTree());
+        copy.numBaseTrees = this.getNumberOfBaseTrees();
+        AbstractCCD.buildCopy(this, copy);
+        // buildCopy overwrites cladeMapping entries for the placeholder root
+        // and emptyClade with fresh copies, so re-resolve the field reference.
+        copy.emptyClade = copy.cladeMapping.get(this.emptyClade.getCladeInBits());
+        copy.emptyClade.setSumCladeCredibilities(1.0);
+        return copy;
+    }
+}

--- a/src/main/java/ccd/model/CCD1CP.java
+++ b/src/main/java/ccd/model/CCD1CP.java
@@ -1,0 +1,116 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.model.bitsets.BitSet;
+
+import java.util.List;
+import java.util.Map;
+
+public class CCD1CP extends CCD1 {
+
+    public CCD1CP(List<Tree> trees, double burnin) {
+        super(trees, burnin);
+    }
+
+    public CCD1CP(TreeAnnotator.TreeSet treeSet) {
+        super(treeSet);
+    }
+
+    public CCD1CP(TreeAnnotator.TreeSet treeSet, int numTreesToUse) {
+        super(treeSet, numTreesToUse);
+    }
+
+    public CCD1CP(TreeAnnotator.TreeSet treeSet, boolean storeBaseTrees) {
+        super(treeSet, storeBaseTrees);
+    }
+
+    public CCD1CP(int numLeaves, boolean storeBaseTrees) {
+        super(numLeaves, storeBaseTrees);
+    }
+
+    /* -- ROOT INITIALIZATION -- */
+    @Override
+    protected void initializeRootClade(int numLeaves) {
+        CPSupport.initializeRoot(this, numLeaves);
+    }
+
+    /* -- TREE INSERTION -- */
+    @Override
+    protected Clade cladifyVertex(Node vertex) {
+        return CPSupport.cladifyVertex(this, vertex);
+    }
+
+    /**
+     * @return whether this clade is marked as a sampled ancestor
+     */
+    @Override
+    public boolean isSampledAncestor(Clade clade) {
+        return CPSupport.isSampledAncestor(clade, leafArraySize);
+    }
+
+    /* -- SAMPLING & MAP -- */
+
+    @Override
+    protected double computeParentHeight(CladePartition partition, Node firstChild, Node secondChild) {
+        return CPSupport.computeParentHeight(partition, firstChild, secondChild, leafArraySize);
+    }
+
+    /* -- HELPER METHODS -- */
+
+    @Override
+    protected Clade reduceCladeCount(Node vertex) {
+        return CPSupport.reduceCladeCount(this, vertex, leafArraySize);
+    }
+
+    @Override
+    protected BitSet computeCladeToNodeMapping(Node vertex, Map<Clade, Node> map) {
+        return CPSupport.computeCladeToNodeMapping(vertex, map, this, leafArraySize);
+    }
+
+    /* -- TREE PROBABILITY -- */
+
+    @Override
+    protected Clade computeProbabilityOfVertex(Node vertex, double[] runningProbability, boolean computeLog) {
+        return CPSupport.computeProbCPVertex(vertex, runningProbability, computeLog, this, leafArraySize);
+    }
+
+    /* -- HELD-OUT (LEAVE-ONE-TREE-OUT) PROBABILITY -- */
+
+    @Override
+    public double getProbOfHeldOutTree(Tree tree, double alpha) {
+        resetCacheIfProbabilitiesDirty();
+        double[] runningProbability = new double[]{1};
+        CPSupport.computeTreeProbabilityHeldOut(this, tree.getRoot(), runningProbability, alpha, false);
+        return runningProbability[0];
+    }
+
+    @Override
+    public double getLogProbOfHeldOutTree(Tree tree, double alpha) {
+        resetCacheIfProbabilitiesDirty();
+        double[] runningProbability = new double[]{0};
+        CPSupport.computeTreeProbabilityHeldOut(this, tree.getRoot(), runningProbability, alpha, true);
+        return runningProbability[0];
+    }
+
+    /* -- MISC -- */
+    @Override
+    public String toString() {
+        return "CCD1-CP " + super.toString().replaceFirst("CCD1 ", "");
+    }
+
+    @Override
+    protected String getSampledAncestorInfoString(Clade clade) {
+        return CPSupport.saInfoString(clade, leafArraySize);
+    }
+
+    @Override
+    public AbstractCCD copy() {
+        CCD1CP copy = new CCD1CP(this.getSizeOfLeavesArray(), false);
+        copy.baseTrees.add(this.getSomeBaseTree());
+        copy.numBaseTrees = this.getNumberOfBaseTrees();
+        AbstractCCD.buildCopy(this, copy);
+        return copy;
+    }
+}

--- a/src/main/java/ccd/model/CCD1SJ.java
+++ b/src/main/java/ccd/model/CCD1SJ.java
@@ -1,0 +1,137 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator.TreeSet;
+
+import java.util.List;
+
+/**
+ * CCD1 with the extended-split (SJ) clade identity for sampled-ancestor trees.
+ *
+ * <p>SJ is the tightest of the four CCD1 SA variants formalised in
+ * {@code CCD_sampled_ancestor/algorithms/alexei_c_four_sa_models.pdf}
+ * (Table 1, row 4): each internal clade carries SA flags for its direct leaf
+ * children only (no propagation), and tree probability is a product over
+ * conditional split probabilities under the full extended-clade identity.
+ * SJ requires every extended split to have been observed as a whole, so
+ * its support is the sampled topologies and SA patterns only — no expand
+ * step. This is the model {@code ccd-js} implements.
+ *
+ * <p>The placeholder {@code rootClade} carries one
+ * {@code (variant, emptyClade)} partition per observed root variant, with
+ * marginal probability {@code variantCount / numBaseTrees}. Identity bitset
+ * layout, key construction, sampling, and tree-probability traversal are all
+ * shared with {@link CCD0SJ} via {@link SJSupport}.
+ *
+ * @see CCD0SJ for the CCD0-normalised companion.
+ */
+public class CCD1SJ extends CCD1 {
+
+    /**
+     * Shared empty sister used in rootClade's (variant, emptyClade) partitions.
+     * Populated in {@link #initializeRootClade} since the super constructor
+     * calls cladifyTree before subclass field initialisers run.
+     */
+    protected Clade emptyClade;
+
+    public CCD1SJ(List<Tree> trees, double burnin) {
+        super(trees, burnin);
+    }
+
+    public CCD1SJ(TreeSet treeSet) {
+        super(treeSet);
+    }
+
+    public CCD1SJ(TreeSet treeSet, int numTreesToUse) {
+        super(treeSet, numTreesToUse);
+    }
+
+    public CCD1SJ(TreeSet treeSet, boolean storeBaseTrees) {
+        super(treeSet, storeBaseTrees);
+    }
+
+    public CCD1SJ(int numLeaves, boolean storeBaseTrees) {
+        super(numLeaves, storeBaseTrees);
+    }
+
+    /* -- ROOT INITIALISATION -- */
+
+    @Override
+    protected void initializeRootClade(int numLeaves) {
+        this.emptyClade = SJSupport.initializeSJRoot(this, numLeaves);
+    }
+
+    /* -- TREE INSERTION -- */
+
+    @Override
+    protected Clade cladifyVertex(Node vertex) {
+        return SJSupport.cladifyTreeRoot(this, emptyClade, vertex);
+    }
+
+    /* -- SA DETECTION & DISPLAY -- */
+
+    @Override
+    public boolean isSampledAncestor(Clade clade) {
+        return SJSupport.isSampledAncestor(clade, leafArraySize);
+    }
+
+    @Override
+    protected String getSampledAncestorInfoString(Clade clade) {
+        return SJSupport.saInfoString(clade, leafArraySize);
+    }
+
+    /* -- TREE PROBABILITY -- */
+
+    @Override
+    protected Clade computeProbabilityOfVertex(Node vertex, double[] runningProbability, boolean computeLog) {
+        return SJSupport.computeTreeProbability(this, emptyClade, vertex, runningProbability, computeLog);
+    }
+
+    /* -- HELD-OUT (LEAVE-ONE-TREE-OUT) PROBABILITY -- */
+    // CCD1's inherited held-out traversal assumes the EL/CP leaf-SA-bit
+    // encoding and fails on SJ clade identities; route through SJSupport instead.
+
+    @Override
+    public double getProbOfHeldOutTree(Tree tree, double alpha) {
+        resetCacheIfProbabilitiesDirty();
+        double[] runningProbability = new double[]{1};
+        SJSupport.computeTreeProbabilityHeldOut(this, emptyClade, tree.getRoot(), runningProbability, alpha, false);
+        return runningProbability[0];
+    }
+
+    @Override
+    public double getLogProbOfHeldOutTree(Tree tree, double alpha) {
+        resetCacheIfProbabilitiesDirty();
+        double[] runningProbability = new double[]{0};
+        SJSupport.computeTreeProbabilityHeldOut(this, emptyClade, tree.getRoot(), runningProbability, alpha, true);
+        return runningProbability[0];
+    }
+
+    /* -- SAMPLING & MAP -- */
+
+    @Override
+    protected Tree getTreeBasedOnStrategy(SamplingStrategy samplingStrategy,
+                                          HeightSettingStrategy heightStrategy) {
+        return SJSupport.buildTree(this, emptyClade, samplingStrategy, heightStrategy);
+    }
+
+    /* -- MISC -- */
+
+    @Override
+    public String toString() {
+        return "CCD1-SJ " + super.toString().replaceFirst("CCD1 ", "");
+    }
+
+    @Override
+    public AbstractCCD copy() {
+        CCD1SJ copy = new CCD1SJ(this.getSizeOfLeavesArray(), false);
+        copy.baseTrees.add(this.getSomeBaseTree());
+        copy.numBaseTrees = this.getNumberOfBaseTrees();
+        AbstractCCD.buildCopy(this, copy);
+        // buildCopy overwrites cladeMapping entries for the placeholder root
+        // and emptyClade with fresh copies, so re-resolve the field reference.
+        copy.emptyClade = copy.cladeMapping.get(this.emptyClade.getCladeInBits());
+        return copy;
+    }
+}

--- a/src/main/java/ccd/model/CCD2.java
+++ b/src/main/java/ccd/model/CCD2.java
@@ -62,8 +62,8 @@ public class CCD2 extends AbstractCCD {
         this.burnin = burnin;
         List<Tree> treesToUse;
         if (burnin == 0) {
-            treesToUse = trees;
             this.numBaseTrees = trees.size();
+            treesToUse = trees;
         } else {
             int numDiscardedTrees = (int) (trees.size() * burnin);
             int numUsedTrees = trees.size() - numDiscardedTrees;
@@ -73,6 +73,7 @@ public class CCD2 extends AbstractCCD {
         }
 
         for (Tree tree : treesToUse) {
+            // cladifyTree(tree, model);
             cladifyTree(tree);
         }
     }
@@ -86,6 +87,7 @@ public class CCD2 extends AbstractCCD {
      *                {@link CCD2}
      */
     public CCD2(TreeSet treeSet) {
+        // this(treeSet, false, model);
         this(treeSet, false);
     }
 
@@ -116,6 +118,7 @@ public class CCD2 extends AbstractCCD {
 
             while (tree != null) {
                 this.numBaseTrees++;
+                // cladifyTree(tree, model);
                 cladifyTree(tree);
 
                 // report progress

--- a/src/main/java/ccd/model/CCDType.java
+++ b/src/main/java/ccd/model/CCDType.java
@@ -19,6 +19,12 @@ public enum CCDType {
             return new CCD1(numberOfLeaves, false);
         }
     },
+    CCD1SJ("CCD1-SJ") {
+        @Override
+        public AbstractCCD emptyCCDOfType(int numberOfLeaves) {
+            return new CCD1SJ(numberOfLeaves, false);
+        }
+    },
     CCD2("CCD2") {
         @Override
         public AbstractCCD emptyCCDOfType(int numberOfLeaves) {
@@ -35,6 +41,16 @@ public enum CCDType {
         @Override
         public AbstractCCD emptyCCDOfType(int numberOfLeaves) {
             return new OptRegCCD(numberOfLeaves);
+        }
+    },
+    KRegCCD("KRegCCD") {
+        @Override
+        public AbstractCCD emptyCCDOfType(int numberOfLeaves) {
+            // KRegCCD needs the whole tree set and mu/alpha at construction (to split-expand,
+            // smooth, and solve the per-clade escape), so it cannot be built empty and fed
+            // trees incrementally. Build it from a tree set / tree list instead.
+            throw new UnsupportedOperationException(
+                    "KRegCCD cannot be built incrementally; construct it from a tree set or list.");
         }
     };
 
@@ -58,6 +74,11 @@ public enum CCDType {
             return CCD1;
         } else if (name.equalsIgnoreCase("2")) {
             return CCD2;
+        } else if (name.equalsIgnoreCase("1sj") || name.equalsIgnoreCase("sj")
+                || name.equalsIgnoreCase("ccd1sj")) {
+            return CCD1SJ;
+        } else if (name.equalsIgnoreCase("kreg") || name.equalsIgnoreCase("kregccd")) {
+            return KRegCCD;
         }
 
         throw new IllegalArgumentException("No CCD type with name '" + name + "' found." +

--- a/src/main/java/ccd/model/CPSupport.java
+++ b/src/main/java/ccd/model/CPSupport.java
@@ -1,0 +1,241 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import ccd.model.bitsets.BitSet;
+
+import java.util.Map;
+
+final class CPSupport {
+    private CPSupport() {
+    }
+
+    static int extendedBitWidth(int leafArraySize) {
+        return leafArraySize + 1;
+    }
+
+    static BitSet leafKey(Node vertex, int leafArraySize) {
+        BitSet key = BitSet.newBitSet(extendedBitWidth(leafArraySize));
+        key.set(vertex.getNr());
+        if (vertex.getLength() != 0) {
+            key.set(leafArraySize);
+        }
+        return key;
+    }
+
+    static BitSet extendedSelfKey(Clade firstChildClade, Clade secondChildClade, int leafArraySize) {
+        BitSet key = BitSet.newBitSet(extendedBitWidth(leafArraySize));
+        key.or(firstChildClade.getCladeInBits());
+        key.or(secondChildClade.getCladeInBits());
+        return key;
+    }
+
+    static void initializeRoot(AbstractCCD ccd, int numLeaves) {
+        ccd.leafArraySize = numLeaves;
+        int width = extendedBitWidth(numLeaves);
+        BitSet rootBitSet = BitSet.newBitSet(width);
+        rootBitSet.set(0, width);
+        ccd.rootClade = new Clade(rootBitSet, ccd);
+        ccd.cladeMapping.put(ccd.rootClade.getCladeInBits(), ccd.rootClade);
+    }
+
+    static Clade cladifyVertex(AbstractCCD ccd, Node vertex) {
+        if (vertex.isLeaf()) {
+            BitSet leafKey = leafKey(vertex, ccd.leafArraySize);
+            Clade leafClade = ccd.cladeMapping.get(leafKey);
+            if (leafClade == null) {
+                leafClade = ccd.addNewClade(leafKey);
+            }
+            leafClade.increaseOccurrenceCount(vertex.getHeight());
+            return leafClade;
+        }
+
+        Clade firstChildClade = cladifyVertex(ccd, vertex.getChildren().get(0));
+        Clade secondChildClade = cladifyVertex(ccd, vertex.getChildren().get(1));
+
+        BitSet selfKey = extendedSelfKey(firstChildClade, secondChildClade, ccd.leafArraySize);
+        Clade currentClade = ccd.cladeMapping.get(selfKey);
+        if (currentClade == null) {
+            currentClade = ccd.addNewClade(selfKey);
+        }
+        currentClade.increaseOccurrenceCount(vertex.getHeight());
+
+        CladePartition partition = currentClade.getCladePartition(firstChildClade, secondChildClade);
+        if (partition == null) {
+            partition = currentClade.createCladePartition(firstChildClade, secondChildClade);
+        }
+        partition.increaseOccurrenceCount(vertex.getHeight());
+
+        return currentClade;
+    }
+
+    static boolean isSampledAncestor(Clade clade, int leafArraySize) {
+        // the last bit, i.e. at index = number of taxa is SA flag
+        // Note: we use 0 to represent SA, and 1 to represent non-SA
+        return !clade.getCladeInBits().get(leafArraySize);
+    }
+
+    static double computeParentHeight(CladePartition partition, Node firstChild, Node secondChild, int leafArraySize) {
+        if (isSampledAncestorPartition(partition, leafArraySize)) {
+            return Math.max(firstChild.getHeight(), secondChild.getHeight());
+        } else {
+            return Math.max(firstChild.getHeight(), secondChild.getHeight()) + 1.0;
+        }
+    }
+
+    static boolean isSampledAncestorPartition(CladePartition partition, int leafArraySize) {
+        return isSampledAncestor(partition.getChildClades()[0], leafArraySize) ||
+                isSampledAncestor(partition.getChildClades()[1], leafArraySize);
+    }
+
+    static Clade reduceCladeCount(AbstractCCD ccd, Node vertex, int leafArraySize) {
+        BitSet cladeInBits = BitSet.newBitSet(extendedBitWidth(leafArraySize));
+
+        if (vertex.isLeaf()) {
+            BitSet leafKey = leafKey(vertex, leafArraySize);
+            Clade leafClade = ccd.cladeMapping.get(leafKey);
+            leafClade.decreaseOccurrenceCount(vertex.getHeight());
+            return leafClade;
+        }
+
+        Clade firstChildClade = reduceCladeCount(ccd, vertex.getChildren().get(0), leafArraySize);
+        Clade secondChildClade = reduceCladeCount(ccd, vertex.getChildren().get(1), leafArraySize);
+
+        BitSet selfKey = extendedSelfKey(firstChildClade, secondChildClade, leafArraySize);
+
+        // retrieve clade and reduce count
+        Clade currentClade = ccd.cladeMapping.get(selfKey);
+        currentClade.decreaseOccurrenceCount(vertex.getHeight());
+
+        // reduce counts for its clade partitions
+        CladePartition currentPartition = currentClade.getCladePartition(firstChildClade, secondChildClade);
+        currentPartition.decreaseOccurrenceCount(vertex.getHeight());
+
+        ccd.removeCladePartitionIfNecessary(currentClade, currentPartition);
+
+        return currentClade;
+    }
+
+    static BitSet computeCladeToNodeMapping(Node vertex, Map<Clade, Node> map, AbstractCCD ccd, int leafArraySize) {
+        BitSet bits;
+        if (vertex.isLeaf()) {
+            bits = leafKey(vertex, leafArraySize);
+        } else {
+            bits = computeCladeToNodeMapping(vertex.getLeft(), map, ccd, leafArraySize);
+            BitSet otherBits = computeCladeToNodeMapping(vertex.getRight(), map, ccd, leafArraySize);
+            bits.or(otherBits);
+        }
+
+        Clade clade = ccd.getClade(bits);
+        if (clade == null) {
+            System.err.println("No clade found in CCD for this vertex (" + bits + ").");
+        }
+        map.put(clade, vertex);
+
+        return bits;
+    }
+
+    static Clade computeProbCPVertex(Node vertex, double[] runningProbability, boolean computeLog, AbstractCCD ccd, int leafArraySize) {
+        if (vertex.isLeaf()) {
+            // set bitSet
+            BitSet leafKey = leafKey(vertex, leafArraySize);
+            Clade leafClade = ccd.cladeMapping.get(leafKey);
+
+            // probability of the leaf
+            if (computeLog) {
+                runningProbability[0] += leafClade.getLogProbability();
+            } else {
+                runningProbability[0] *= leafClade.getProbability();
+            }
+            return leafClade;
+        }
+
+        Clade firstChildClade = computeProbCPVertex(vertex.getChildren().get(0), runningProbability, computeLog, ccd, leafArraySize);
+        Clade secondChildClade = computeProbCPVertex(vertex.getChildren().get(1), runningProbability, computeLog, ccd, leafArraySize);
+
+        if (computeLog && runningProbability[0] > 0) {
+            return null;
+        }
+
+        if ((firstChildClade == null) || (secondChildClade == null)) {
+            ccd.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        BitSet selfKey = extendedSelfKey(firstChildClade, secondChildClade, leafArraySize);
+        Clade currentClade = ccd.cladeMapping.get(selfKey);
+        if (currentClade != null) {
+            CladePartition partition = currentClade.getCladePartition(firstChildClade, secondChildClade);
+            if (partition != null) {
+                if (computeLog) {
+                    runningProbability[0] += partition.getLogCCP();
+                } else {
+                    runningProbability[0] *= partition.getCCP();
+                }
+            } else {
+                ccd.setComputedNoProbability(runningProbability, computeLog);
+            }
+        } else {
+            ccd.setComputedNoProbability(runningProbability, computeLog);
+        }
+        return currentClade;
+    }
+
+    /* -- HELD-OUT (LEAVE-ONE-TREE-OUT) TREE PROBABILITY -- */
+
+    static Clade computeTreeProbabilityHeldOut(AbstractCCD ccd, Node root, double[] runningProbability, double alpha, boolean computeLog) {
+        Clade variant = computeProbCPVertexHeldOut(ccd, root, runningProbability, alpha, computeLog);
+        return variant;
+    }
+
+    private static Clade computeProbCPVertexHeldOut(AbstractCCD ccd, Node vertex, double[] runningProbability, double alpha, boolean computeLog) {
+        if (vertex.isLeaf()) {
+            BitSet leafKey = leafKey(vertex, ccd.leafArraySize);
+            Clade leafClade = ccd.cladeMapping.get(leafKey);
+            if (leafClade == null) {
+                AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+                return null;
+            }
+            return leafClade;
+        }
+
+        Clade firstChildClade = computeProbCPVertexHeldOut(ccd, vertex.getChildren().get(0), runningProbability, alpha, computeLog);
+        Clade secondChildClade = computeProbCPVertexHeldOut(ccd, vertex.getChildren().get(1), runningProbability, alpha, computeLog);
+
+        if (firstChildClade == null || secondChildClade == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        BitSet selfKey = extendedSelfKey(firstChildClade, secondChildClade, ccd.leafArraySize);
+        Clade currentClade = ccd.cladeMapping.get(selfKey);
+
+        // A clade seen in exactly one tree exists only because of the held-out
+        // tree; the held-out model has never seen it, so contribute no probability
+        // (also avoids a zero denominator in the held-out CCP at alpha=0).
+        if (currentClade == null || currentClade.getNumberOfOccurrences() == 1) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        CladePartition partition = currentClade.getCladePartition(firstChildClade, secondChildClade);
+        if (partition == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        if (computeLog) {
+            runningProbability[0] += partition.getLogCCPInHeldOutTree(alpha);
+        } else {
+            runningProbability[0] *= partition.getCCPInHeldOutTree(alpha);
+        }
+        return currentClade;
+    }
+
+    static String saInfoString(Clade clade, int leafArraySize) {
+        BitSet bits = clade.getCladeInBits();
+        boolean isNonSA = bits.get(leafArraySize);
+        return isNonSA ? "sampled ancestor = false" : "sampled ancestor = true";
+    }
+
+}
+

--- a/src/main/java/ccd/model/Clade.java
+++ b/src/main/java/ccd/model/Clade.java
@@ -32,12 +32,23 @@ public class Clade {
      * BitSet representation of this clade. The mapping of bits to taxa is
      * implicit here, explicit in a global context.
      */
-    private final BitSet cladeAsBitSet;
+    private BitSet cladeAsBitSet;
+
+    /**
+     * BitSet representation of this clade, with only the taxa bits, excluding the sampled ancestor flag bit.
+     * The mapping of bits to taxa is implicit here, explicit in a global context.
+     */
+    private BitSet cladeAsBitSetTaxaOnly;
 
     /**
      * Number of taxa in this clade.
      */
-    private final int size;
+    private int size;
+
+    /**
+     * Total number of taxa in the tree this clade belongs to.
+     */
+    private final int numTaxaInTree;
 
     /**
      * The number of times this clade occurs in the processed set of trees.
@@ -52,6 +63,13 @@ public class Clade {
 
     /** Custom parameter associated with this clade. */
     private double parameter = -1;
+
+    /**
+     * Whether this clade was introduced by NNI clade expansion (i.e. it is not
+     * an observed clade). Used by two-level regularisation to give NNI-derived
+     * splits a separate pseudocount.
+     */
+    private boolean nniExpanded = false;
 
     /**
      * Child clades this clade is split into.
@@ -136,7 +154,33 @@ public class Clade {
     public Clade(BitSet cladeInBits, AbstractCCD abstractCCD) {
         this.ccd = abstractCCD;
         this.cladeAsBitSet = cladeInBits;
-        this.size = cladeInBits.cardinality();
+        this.numTaxaInTree = abstractCCD.leafArraySize;
+        this.cladeAsBitSetTaxaOnly = cladeInBits.getSubset(0, numTaxaInTree);
+        this.size = cladeAsBitSetTaxaOnly.cardinality(); // counting #bits set to 1 excluding sampled ancestor bits
+        this.parentClades = new ArrayList<Clade>(4);
+        this.partitions = new ArrayList<CladePartition>(5);
+        this.childClades = new ArrayList<Clade>(8);
+
+        if (size == 1) {
+            this.maxSubtreeLogCCP = 0;
+            this.maxSubtreeSumCladeCredibility = 1;
+            this.probability = 1;
+            this.sumCladeCredibilities = 1;
+        }
+    }
+
+    /**
+     * Construct an empty Clade given a CCD. This clade is represented by an empty BitSet
+     * with placeholders for #taxa = #leaves the trees this CCD is based on.
+     *
+     * @param abstractCCD CCD this clade is part of
+     */
+    public Clade(AbstractCCD abstractCCD) {
+        this.ccd = abstractCCD;
+        this.numTaxaInTree = abstractCCD.leafArraySize;
+        this.cladeAsBitSet = BitSet.newBitSet(numTaxaInTree);
+        this.cladeAsBitSetTaxaOnly = BitSet.newBitSet(numTaxaInTree);
+        this.size = cladeAsBitSetTaxaOnly.cardinality(); // counting #bits set to 1 excluding sampled ancestor bits
         this.parentClades = new ArrayList<Clade>(4);
         this.partitions = new ArrayList<CladePartition>(5);
         this.childClades = new ArrayList<Clade>(8);
@@ -160,6 +204,7 @@ public class Clade {
         Clade copiedClade = new Clade((BitSet) this.cladeAsBitSet.clone(), targetCCD);
         copiedClade.increaseOccurrenceCountBy(getNumberOfOccurrences(), getMeanOccurredHeight());
         copiedClade.setCladeParameter(this.getCladeParameter());
+        copiedClade.setNNIExpanded(this.isNNIExpanded());
         return copiedClade;
     }
 
@@ -286,7 +331,6 @@ public class Clade {
         }
     }
 
-
     /* -- STATE MANAGEMENT -- */
 
     /**
@@ -348,7 +392,6 @@ public class Clade {
      */
     protected void increaseOccurrenceCount(double height) {
         this.meanHeight = (meanHeight * numOccurrences + height) / (numOccurrences + 1);
-
         increaseOccurrenceCount();
     }
 
@@ -432,6 +475,10 @@ public class Clade {
         return cladeAsBitSet;
     }
 
+    public BitSet getCladeInBitsTaxaOnly() {
+        return cladeAsBitSetTaxaOnly;
+    }
+
     /**
      * @return whether this clade represents a leaf
      */
@@ -462,10 +509,11 @@ public class Clade {
 
     @Override
     public String toString() {
-        return "Clade [taxa = " + cladeAsBitSet + ", numOccurrences = " + numOccurrences
-                // + ", ccd = " + ccd
-                + ", num partitions = " + partitions.size()
-                + ", parameter = " + ((parameter < 0) ? getCladeCredibility() : parameter) + "]";
+        return "Clade [taxa = " + cladeAsBitSetTaxaOnly + ", " +
+                ccd.getSampledAncestorInfoString(this) +
+                ", numOccurrences = " + numOccurrences +
+                ", num partitions = " + partitions.size() +
+                ", parameter = " + ((parameter < 0) ? getCladeCredibility() : parameter) + "]";
     }
 
     /**
@@ -582,6 +630,15 @@ public class Clade {
         return this.parameter;
     }
 
+    /** @return whether this clade was introduced by NNI clade expansion */
+    public boolean isNNIExpanded() {
+        return this.nniExpanded;
+    }
+
+    /** @param nniExpanded whether this clade was introduced by NNI clade expansion */
+    public void setNNIExpanded(boolean nniExpanded) {
+        this.nniExpanded = nniExpanded;
+    }
 
     /* -- GETTERS RECURSIVE VALUES -- */
 
@@ -609,11 +666,9 @@ public class Clade {
 
                     runningEntropy -= probability * (logprobability - entropyFirstChild - entropySecondChild);
                 }
-
                 this.entropy = runningEntropy;
             }
         }
-
         return entropy;
     }
 
@@ -711,7 +766,7 @@ public class Clade {
                     BitSet bitsMax = smallCladeMax.getCladeInBits();
                     BitSet bitsCurrent = smallCladeCurrent.getCladeInBits();
 
-                    if (bitsMax.equals(bitsCurrent)) {
+                    if (maxSubtreeCCPPartition.equivalentToPartition(partition)) {
                         System.err.println(maxSubtreeCCPPartition);
                         System.err.println(partition);
                         throw new AssertionError("Tie breaking failed - duplicate partitions detected!");
@@ -880,6 +935,16 @@ public class Clade {
     }
 
     /**
+     * Returns the log probability of this clade appearing in a tree
+     * of a distribution ({@link ITreeDistribution}).
+     *
+     * @return log probability of this clade appearing in a tree
+     */
+    public double getLogProbability() {
+        return Math.log(probability);
+    }
+
+    /**
      * Set the probability of this clade appearing in a tree of its distribution
      * ({@link ITreeDistribution}).
      *
@@ -900,7 +965,7 @@ public class Clade {
      * @return whether this clade contains the given clade as subclade
      */
     public boolean containsClade(Clade potentialSubclade) {
-        return contains(potentialSubclade.getCladeInBits());
+        return contains(potentialSubclade.getCladeInBitsTaxaOnly());
     }
 
     /**
@@ -910,7 +975,7 @@ public class Clade {
      * @return whether this clade contains the given filter
      */
     public boolean contains(BitSet mask) {
-        return BitSetUtil.contains(this.cladeAsBitSet, mask);
+        return BitSetUtil.contains(this.cladeAsBitSetTaxaOnly, mask);
     }
 
     /**
@@ -920,7 +985,7 @@ public class Clade {
      * @return whether this clade is contained in the given BitSet
      */
     public boolean contained(BitSet mask) {
-        return BitSetUtil.contains(mask, this.cladeAsBitSet);
+        return BitSetUtil.contains(mask, this.cladeAsBitSetTaxaOnly);
     }
 
     /**
@@ -930,7 +995,7 @@ public class Clade {
      * @return whether this clade intersects the given clade
      */
     public boolean intersects(Clade potentialIntersectedClade) {
-        return this.intersects(potentialIntersectedClade.getCladeInBits());
+        return this.intersects(potentialIntersectedClade.getCladeInBitsTaxaOnly());
     }
 
     /**
@@ -940,7 +1005,7 @@ public class Clade {
      * @return whether this clade intersects the given filter
      */
     public boolean intersects(BitSet mask) {
-        return this.cladeAsBitSet.intersects(mask);
+        return this.cladeAsBitSetTaxaOnly.intersects(mask);
     }
 
     /**
@@ -953,6 +1018,29 @@ public class Clade {
         return this.cladeAsBitSet.equals(mask);
     }
 
+    public boolean equals(Clade anotherClade) {
+        return this.cladeAsBitSet.equals(anotherClade.cladeAsBitSet);
+    }
+
+    /**
+     * Returns whether this clade contains the same taxa as the given clade.
+     *
+     * @param anotherClade to be tested if contains the same taxa as this clade
+     * @return whether this clade contains the same taxa as the given clade
+     */
+    public boolean hasSameTaxa(Clade anotherClade) {
+        return this.cladeAsBitSetTaxaOnly.equals(anotherClade.cladeAsBitSetTaxaOnly);
+    }
+
+    /**
+     * Returns whether this clade contains the same taxa as the given BitSet.
+     *
+     * @param mask to be tested if contains the same taxa as this clade
+     * @return whether this clade contains the same taxa as the given filter
+     */
+    public boolean hasSameTaxa(BitSet mask) {
+        return this.cladeAsBitSetTaxaOnly.equals(mask);
+    }
 
     /* -- BASE CLADE FOR FILTERED CCDs -- */
 

--- a/src/main/java/ccd/model/CladePartition.java
+++ b/src/main/java/ccd/model/CladePartition.java
@@ -255,7 +255,6 @@ public class CladePartition {
                 && this.containsChildClade(otherPartition.getChildClades()[1]);
     }
 
-
     /* -- GETTERS RECURSIVE VALUES -- */
 
     /** @return the number of tree topologies with this partition at the root */
@@ -321,10 +320,12 @@ public class CladePartition {
         }
     }
 
-    /* Precompute log values for quick lookup */
-    private static double[] logTable;
+    /* Precompute log values for quick lookup. Volatile so that a table grown by one thread (see
+     * growLogTable) is safely published to readers -- the table is shared across all CladePartition
+     * instances and may be read concurrently when CCDs are built/sampled in parallel. */
+    private static volatile double[] logTable;
 
-    private static int logTableLength = 1024;
+    private static final int logTableLength = 1024;
 
     static {
         logTable = new double[logTableLength];
@@ -347,20 +348,34 @@ public class CladePartition {
                         - logTable[this.getParentClade().getNumberOfOccurrences()];
                 return logCCP;
             } catch (ArrayIndexOutOfBoundsException e) {
-                // if our table of log wasn't long enough
-                int oldLength = logTable.length;
-                double[] tmp = new double[oldLength + logTableLength];
-                System.arraycopy(logTable, 0, tmp, 0, oldLength);
-                for (int i = oldLength; i < tmp.length; i++) {
-                    tmp[i] = Math.log(i);
-                }
-                logTable = tmp;
-
+                // if our table of log wasn't long enough, grow it (thread-safely) and retry
+                growLogTable(Math.max(this.numOccurrences, this.getParentClade().getNumberOfOccurrences()));
                 return getLogCCP();
             }
         } else {
             return Math.log(this.ccp);
         }
+    }
+
+    /**
+     * Grows the shared log lookup table so index {@code minIndex} is valid, then publishes it. Every
+     * entry is {@code log(i)}, so concurrent growers compute identical values; the synchronized block
+     * with a re-check just avoids redundant work and the unsafe publication of a half-filled array.
+     */
+    private static synchronized void growLogTable(int minIndex) {
+        if (minIndex < logTable.length) {
+            return; // another thread already grew it past minIndex
+        }
+        int newLength = logTable.length;
+        while (minIndex >= newLength) {
+            newLength += logTableLength;
+        }
+        double[] tmp = new double[newLength];
+        System.arraycopy(logTable, 0, tmp, 0, logTable.length);
+        for (int i = logTable.length; i < tmp.length; i++) {
+            tmp[i] = Math.log(i);
+        }
+        logTable = tmp;
     }
 
     /**
@@ -436,7 +451,6 @@ public class CladePartition {
                 maxSubtreeLogCCP += clade.getMaxSubtreeLogCCP();
             }
         }
-
         return maxSubtreeLogCCP;
     }
 

--- a/src/main/java/ccd/model/FilteredCCD.java
+++ b/src/main/java/ccd/model/FilteredCCD.java
@@ -362,7 +362,6 @@ public class FilteredCCD extends AbstractCCD {
         }
     }
 
-
     @Override
     public FilteredCCD copy() {
         throw new UnsupportedOperationException("Copying a filtered CCD is by design not supported.");
@@ -371,7 +370,7 @@ public class FilteredCCD extends AbstractCCD {
     @Override
     public void initialize() {
         if (this.rootCCD instanceof CCD0) {
-            CCD0.setPartitionProbabilities(this.rootClade);
+            ((CCD0) rootCCD).setPartitionProbabilities(rootClade);
             this.probabilitiesDirty = false;
         }
     }

--- a/src/main/java/ccd/model/GRegCCD.java
+++ b/src/main/java/ccd/model/GRegCCD.java
@@ -1,0 +1,217 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * GRegCCD -- the Geometrically-Regularised CCD: a one-parameter, full-support tree distribution in
+ * which every <em>unobserved</em> clade-split is priced by a single escape rate {@code eps} (observed
+ * splits keep their sample count). A tree's probability is
+ * <pre>
+ *   P(T) = eps^(s(T)) / Z,    s(T) = number of (clade -> split) pairs of T not seen in the sample,
+ * </pre>
+ * i.e. a geometric law in split-novelty distance. This unifies RegCCD's {@code alpha} split-expansion
+ * (a recombination of observed clades is one new split) and KRegCCD's {@code mu} escape (a novel clade
+ * costs its creating split plus its own split, i.e. >= 2 new splits) into a single rate, so there is no
+ * {@code alpha} and no per-clade reserve depth.
+ *
+ * <p>Unlike KRegCCD it is <em>exactly</em> normalised, because {@code Z} is the true partition function
+ * of the standard CCD sum-product
+ * <pre>
+ *   W(S) = sum over bipartitions {L,R} of S of  w(S -> L|R) * W(L) * W(R),   Z = W(rootClade),
+ * </pre>
+ * with {@code w} the observed count or {@code eps} for any unseen bipartition. A subset {@code S} that
+ * contains no observed clade is <em>fresh</em>: every bipartition is priced {@code eps}, so {@code W(S)}
+ * depends only on {@code |S|} and equals the universal {@code g(|S|)} computed once by
+ * {@code g(m) = eps * (1/2) * sum_{j=1}^{m-1} C(m,j) g(j) g(m-j)}.
+ *
+ * <p>{@code Z} is computed exactly by a subset DP, which is {@code O(3^n)} and so feasible only up to
+ * {@link #MAX_EXACT_TAXA} taxa. A tractable large-{@code n} approximation of {@code Z} (fresh-set term
+ * plus low-order observed-clade corrections, mirroring KRegCCD's reserve decoupling) is future work; the
+ * scoring of a given tree, {@code s(T)}, is always cheap.
+ */
+public class GRegCCD {
+
+    /** Largest taxon count for which the exact O(3^n) partition function is computed. */
+    public static final int MAX_EXACT_TAXA = 16;
+
+    private final int nTaxa;
+    private final double eps;
+    private final double logEps;
+
+    /** (cladeMask, minChildMask) -> observed split count. */
+    private final Map<Long, Double> obsWeight = new HashMap<>();
+    /** Masks of observed clades (split parents); used to detect fresh subsets. */
+    private final long[] observedClades;
+
+    private final double[] g;          // g[m] = W of a fresh m-set
+    private final Map<Long, Double> wMemo = new HashMap<>();
+    private final double logZ;
+
+    public GRegCCD(List<Tree> trees, double eps) {
+        if (eps <= 0 || eps >= 1) {
+            throw new IllegalArgumentException("eps must be in (0, 1), got " + eps);
+        }
+        this.eps = eps;
+        this.logEps = Math.log(eps);
+        this.nTaxa = trees.get(0).getLeafNodeCount();
+
+        Set<Long> cladeSet = new HashSet<>();
+        for (Tree t : trees) {
+            recordSplits(t.getRoot(), cladeSet);
+        }
+        this.observedClades = cladeSet.stream().mapToLong(Long::longValue).sorted().toArray();
+
+        this.g = freshSetWeights(nTaxa, eps);
+
+        long full = (nTaxa == 64) ? -1L : (1L << nTaxa) - 1;
+        if (nTaxa > MAX_EXACT_TAXA) {
+            throw new UnsupportedOperationException(
+                    "GRegCCD exact normalisation is O(3^n); n=" + nTaxa + " exceeds MAX_EXACT_TAXA="
+                            + MAX_EXACT_TAXA + ". A tractable approximate Z is not yet implemented.");
+        }
+        this.logZ = Math.log(W(full));
+    }
+
+    /* ---- construction: observed split weights ---- */
+
+    private long recordSplits(Node v, Set<Long> cladeSet) {
+        if (v.isLeaf()) {
+            return 1L << v.getNr();
+        }
+        long l = recordSplits(v.getChildren().get(0), cladeSet);
+        long r = recordSplits(v.getChildren().get(1), cladeSet);
+        long mask = l | r;
+        cladeSet.add(mask);
+        obsWeight.merge(splitKey(mask, l, r), 1.0, Double::sum);
+        return mask;
+    }
+
+    private static long splitKey(long mask, long childA, long childB) {
+        return (mask << 32) | Math.min(childA, childB);
+    }
+
+    /* ---- universal fresh-set partition function g(m) ---- */
+
+    private static double[] freshSetWeights(int n, double eps) {
+        long[][] c = new long[n + 1][n + 1];
+        for (int m = 0; m <= n; m++) {
+            c[m][0] = 1;
+            for (int k = 1; k <= m; k++) {
+                c[m][k] = c[m - 1][k - 1] + (k <= m - 1 ? c[m - 1][k] : 0);
+            }
+        }
+        double[] g = new double[n + 1];
+        if (n >= 1) g[1] = 1.0;
+        for (int m = 2; m <= n; m++) {
+            double s = 0;
+            for (int j = 1; j <= m - 1; j++) {
+                s += c[m][j] * g[j] * g[m - j];
+            }
+            g[m] = eps * 0.5 * s;
+        }
+        return g;
+    }
+
+    /* ---- exact partition function over all rooted trees on `mask` ---- */
+
+    private double W(long mask) {
+        int size = Long.bitCount(mask);
+        if (size == 1) {
+            return 1.0;
+        }
+        if (isFresh(mask)) {
+            return g[size];
+        }
+        Double memo = wMemo.get(mask);
+        if (memo != null) {
+            return memo;
+        }
+        long low = mask & (-mask);
+        double sum = 0.0;
+        for (long sub = mask; sub != 0; sub = (sub - 1) & mask) {
+            if ((sub & low) == 0 || sub == mask) {
+                continue; // L contains the lowest bit; R = mask ^ sub nonempty
+            }
+            long L = sub, R = mask ^ sub;
+            double w = obsWeight.getOrDefault(splitKey(mask, L, R), eps);
+            sum += w * W(L) * W(R);
+        }
+        wMemo.put(mask, sum);
+        return sum;
+    }
+
+    /** A subset is fresh (W == g[size]) iff it contains no observed clade as a subset. */
+    private boolean isFresh(long mask) {
+        for (long c : observedClades) {
+            if ((c & ~mask) == 0) { // c subset of mask
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /* ---- scoring ---- */
+
+    public double getLogProbabilityOfTree(Tree tree) {
+        double[] logProd = {0.0};
+        scoreSplits(tree.getRoot(), logProd);
+        return logProd[0] - logZ;
+    }
+
+    public double getProbabilityOfTree(Tree tree) {
+        return Math.exp(getLogProbabilityOfTree(tree));
+    }
+
+    /** Always true: every tree on this taxon set has positive probability. */
+    public boolean containsTree(Tree tree) {
+        return true;
+    }
+
+    /** Number of (clade -> split) pairs of the tree that were never seen in the sample. */
+    public int novelSplitCount(Tree tree) {
+        int[] count = {0};
+        scoreSplits(tree.getRoot(), new double[1], count);
+        return count[0];
+    }
+
+    private long scoreSplits(Node v, double[] logProd) {
+        return scoreSplits(v, logProd, null);
+    }
+
+    private long scoreSplits(Node v, double[] logProd, int[] novel) {
+        if (v.isLeaf()) {
+            return 1L << v.getNr();
+        }
+        long l = scoreSplits(v.getChildren().get(0), logProd, novel);
+        long r = scoreSplits(v.getChildren().get(1), logProd, novel);
+        long mask = l | r;
+        Double w = obsWeight.get(splitKey(mask, l, r));
+        if (w == null) {
+            logProd[0] += logEps;
+            if (novel != null) novel[0]++;
+        } else {
+            logProd[0] += Math.log(w);
+        }
+        return mask;
+    }
+
+    public double getEpsilon() {
+        return eps;
+    }
+
+    public double getLogPartitionFunction() {
+        return logZ;
+    }
+
+    @Override
+    public String toString() {
+        return "GRegCCD [eps = " + eps + ", taxa = " + nTaxa + ", logZ = " + logZ + "]";
+    }
+}

--- a/src/main/java/ccd/model/GRegZApprox.java
+++ b/src/main/java/ccd/model/GRegZApprox.java
@@ -1,0 +1,175 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import ccd.model.bitsets.BitSet;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tractable approximation of the GRegCCD partition function Z = W(rootClade) for large taxon sets,
+ * where the exact O(3^n) sum is infeasible. Recurses over the OBSERVED clade DAG, pricing every
+ * escape into a fresh remainder by the universal fresh-set weight g(m) and keeping recombinations
+ * into two observed clades exact:
+ * <pre>
+ *   W(C) = g(|C|) + sum over observed clades A strict-subset of C of
+ *          [ w(C->{A, C\A}) * Wtilde(A) * Wtilde(C\A)  -  eps * g(|A|) * g(|C\A|) ],
+ * </pre>
+ * with w = observed split count (else eps), and Wtilde(X) = W(X) if X is an observed clade else
+ * g(|X|). Exact for observed trees and one-recombination ("one new split") trees; deeper novelty
+ * (subsets that contain an observed clade but are not themselves observed, e.g. an observed cherry
+ * plus a stray taxon) is approximated as fresh, an O(eps^2)-per-clade error. All terms are
+ * non-negative, so the recursion is carried in log space (log-sum-exp) without cancellation.
+ *
+ * <p>Validated against {@link GRegCCD}'s exact Z on small enumerable sets ({@code GRegZApproxTest}).
+ */
+public class GRegZApprox {
+
+    private final int nTaxa;
+    private final List<BitSet> clades;                 // observed clades (incl. root + singletons)
+    private final java.util.Set<BitSet> cladeSet;
+    private final Map<BitSet, Map<BitSet, Double>> obsSplit; // parent -> canonChild -> count
+    private final BitSet root;
+
+    private double[] logG;
+    private double eps, logEps;
+    private Map<BitSet, Double> memo;
+
+    private GRegZApprox(int n, List<BitSet> clades, java.util.Set<BitSet> cladeSet,
+                        Map<BitSet, Map<BitSet, Double>> obsSplit, BitSet root) {
+        this.nTaxa = n;
+        this.clades = clades;
+        this.cladeSet = cladeSet;
+        this.obsSplit = obsSplit;
+        this.root = root;
+    }
+
+    public static GRegZApprox fromTrees(List<Tree> trees) {
+        int n = trees.get(0).getLeafNodeCount();
+        Map<BitSet, Map<BitSet, Double>> obsSplit = new HashMap<>();
+        java.util.Set<BitSet> cladeSet = new java.util.HashSet<>();
+        for (Tree t : trees) {
+            Map<Node, BitSet> bits = new HashMap<>();
+            computeBits(t.getRoot(), bits, n);
+            for (Node v : t.getNodesAsArray()) {
+                BitSet pb = bits.get(v);
+                cladeSet.add(pb);
+                if (v.isLeaf()) {
+                    continue;
+                }
+                BitSet canon = canonChild(pb, bits.get(v.getChildren().get(0)), bits.get(v.getChildren().get(1)));
+                obsSplit.computeIfAbsent(pb, k -> new HashMap<>()).merge(canon, 1.0, Double::sum);
+            }
+        }
+        BitSet root = BitSet.newBitSet(n);
+        root.set(0, n);
+        List<BitSet> clades = new ArrayList<>(cladeSet);
+        clades.sort((a, b) -> Integer.compare(a.cardinality(), b.cardinality()));
+        return new GRegZApprox(n, clades, cladeSet, obsSplit, root);
+    }
+
+    /** Approximate log Z at the given escape rate. */
+    public double logZ(double eps) {
+        this.eps = eps;
+        this.logEps = Math.log(eps);
+        this.logG = freshLogWeights(nTaxa, logEps);
+        this.memo = new HashMap<>();
+        return logW(root);
+    }
+
+    private double logW(BitSet C) {
+        int size = C.cardinality();
+        if (size == 1) {
+            return 0.0;
+        }
+        Double m = memo.get(C);
+        if (m != null) {
+            return m;
+        }
+        int low = C.nextSetBit(0);
+        double acc = logG[size];
+        Map<BitSet, Double> splits = obsSplit.get(C);
+        for (BitSet A : clades) {
+            int aCard = A.cardinality();
+            if (aCard >= size) {
+                continue; // strict subset only (clades sorted ascending, but cheap to test)
+            }
+            if (!subset(A, C)) {
+                continue;
+            }
+            BitSet B = BitSet.newBitSet(C);
+            B.andNot(A);
+            if (B.isEmpty()) {
+                continue;
+            }
+            boolean aHasLow = A.get(low);
+            boolean bInD = cladeSet.contains(B);
+            if (!aHasLow && bInD) {
+                continue; // bipartition will be (or was) counted from B's side
+            }
+            BitSet canon = aHasLow ? A : B;
+            Double cnt = (splits == null) ? null : splits.get(canon);
+            double w = (cnt != null) ? cnt : eps;
+
+            int bCard = B.cardinality();
+            double logWA = logW(A);
+            double logWB = bInD ? logW(B) : logG[bCard];
+            double logA = Math.log(w) + logWA + logWB;
+            double logB = logEps + logG[aCard] + logG[bCard];
+            if (logA > logB) {
+                // log(exp(logA) - exp(logB)) stably for logA >= logB (expm1(logA-logB) overflows)
+                double logTerm = logA + Math.log1p(-Math.exp(logB - logA));
+                acc = logSumExp(acc, logTerm);
+            }
+        }
+        memo.put(C, acc);
+        return acc;
+    }
+
+    /* ---- helpers ---- */
+
+    /** log g(m): g(m) = eps^(m-1) * (2m-3)!! (the fresh / uniform partition function on m taxa). */
+    private static double[] freshLogWeights(int n, double logEps) {
+        double[] logG = new double[n + 1];
+        double logDoubleFact = 0.0; // log of (2m-3)!! accumulated
+        if (n >= 1) logG[1] = 0.0;
+        for (int m = 2; m <= n; m++) {
+            logDoubleFact += Math.log(2 * m - 3); // multiply in the next odd factor
+            logG[m] = (m - 1) * logEps + logDoubleFact;
+        }
+        return logG;
+    }
+
+    private static boolean subset(BitSet a, BitSet c) {
+        BitSet tmp = BitSet.newBitSet(a);
+        tmp.andNot(c);
+        return tmp.isEmpty();
+    }
+
+    private static double logSumExp(double a, double b) {
+        if (a == Double.NEGATIVE_INFINITY) return b;
+        if (b == Double.NEGATIVE_INFINITY) return a;
+        double max = Math.max(a, b);
+        return max + Math.log(Math.exp(a - max) + Math.exp(b - max));
+    }
+
+    private static BitSet canonChild(BitSet parent, BitSet c0, BitSet c1) {
+        int lb = parent.nextSetBit(0);
+        return c0.get(lb) ? c0 : c1;
+    }
+
+    private static BitSet computeBits(Node v, Map<Node, BitSet> bits, int n) {
+        BitSet b = BitSet.newBitSet(n);
+        if (v.isLeaf()) {
+            b.set(v.getNr());
+        } else {
+            b.or(computeBits(v.getChildren().get(0), bits, n));
+            b.or(computeBits(v.getChildren().get(1), bits, n));
+        }
+        bits.put(v, b);
+        return b;
+    }
+}

--- a/src/main/java/ccd/model/ITreeDistribution.java
+++ b/src/main/java/ccd/model/ITreeDistribution.java
@@ -32,6 +32,8 @@ public interface ITreeDistribution {
      */
     public double sampleTreeProbability();
 
+    public double sampleTreeLogProbability();
+
     /**
      * Returns the tree (without heights set) with maximum probability in this
      * distribution.
@@ -59,6 +61,8 @@ public interface ITreeDistribution {
      * @return the probability of the given tree
      */
     public double getProbabilityOfTree(Tree tree);
+
+    public double getLogProbabilityOfTree(Tree tree);
 
     /**
      * Returns whether this distribution contains the given tree.

--- a/src/main/java/ccd/model/KRegCCD.java
+++ b/src/main/java/ccd/model/KRegCCD.java
@@ -417,6 +417,205 @@ public class KRegCCD extends RegCCD {
     }
 
     /**
+     * Buffer-reusing variant of {@link #getLogProbabilityOfTree(Tree)} for repeated scoring (e.g. an SPR
+     * operator scoring every re-attachment of a pruned subtree): the caller supplies a scratch map whose
+     * per-node {@link BitSet}s are CLEARED and reused rather than reallocated, removing the per-call
+     * {@code HashMap} and per-node {@code BitSet} allocation that dominates such loops. Entries for nodes not in
+     * {@code tree} are harmless (only nodes reachable from the root are written and read). Returns exactly the
+     * same value as {@link #getLogProbabilityOfTree(Tree)}.
+     */
+    public double getLogProbabilityOfTree(Tree tree, Map<Node, BitSet> scratch) {
+        computeBitsReusing(tree.getRoot(), scratch);
+        double[] logp = new double[]{0.0};
+        scoreFresh(tree.getRoot(), scratch, logp, mu, true);
+        return logp[0];
+    }
+
+    /** As {@link #computeBits} but reuses each node's {@link BitSet} from {@code bits} (clear + recompute)
+     *  instead of allocating a fresh one, so repeated calls on stable node objects do not allocate. */
+    private BitSet computeBitsReusing(Node v, Map<Node, BitSet> bits) {
+        BitSet b = bits.get(v);
+        if (b == null) {
+            b = BitSet.newBitSet(leafArraySize);
+            bits.put(v, b);
+        } else {
+            b.clear();
+        }
+        if (v.isLeaf()) {
+            b.set(v.getNr());
+        } else {
+            b.or(computeBitsReusing(v.getChildren().get(0), bits));
+            b.or(computeBitsReusing(v.getChildren().get(1), bits));
+        }
+        return b;
+    }
+
+    /**
+     * Incrementally score EVERY single-leaf re-graft of leaf {@code leafIndex} onto {@code reduced} (a tree that
+     * does NOT contain that leaf): for each target node {@code x}, the full-support log-probability of the tree
+     * obtained by attaching the leaf on the branch above {@code x}. This is the engine for a CCD-guided SPR/Gibbs
+     * operator that must score all {@code ~2n} re-attachments per move; scoring each independently with
+     * {@link #getLogProbabilityOfTree(Tree)} is {@code O(n)} each ({@code O(n^2)} total), dominated by re-walking
+     * the unchanged backbone. Here the backbone is priced ONCE: {@code subScore[v]} = the self-contained
+     * full-support score of {@code v}'s subtree, then each re-graft is a MEMOISED {@code scoreFresh} that returns
+     * the cached {@code subScore} for any subtree not containing the leaf, so the recursion only descends the
+     * leaf's insertion path. Result is identical to {@link #getLogProbabilityOfTree(Tree)} of the spliced tree.
+     *
+     * @param reduced   a tree on the taxon set MINUS the leaf (leaves carry this CCD's canonical numbering)
+     * @param leafIndex the canonical index of the leaf being re-grafted
+     * @param targets   the nodes above which to score an attachment (must exclude the root); {@code null} = all
+     *                  non-root nodes
+     * @return map from each target node to the log-probability of attaching the leaf above it
+     */
+    public Map<Node, Double> logProbabilityOfAllRegrafts(Tree reduced, int leafIndex, List<Node> targets) {
+        Map<Node, BitSet> bits = new HashMap<>();
+        computeBits(reduced.getRoot(), bits);
+
+        // price the backbone once: self-contained subtree score for every node (only OBSERVED-clade nodes are ever
+        // read back, but the post-order recurses through novel-clade interiors to reach their observed boundaries)
+        Map<Node, Double> subScore = new HashMap<>();
+        computeSubtreeScores(reduced.getRoot(), bits, subScore);
+
+        // spare nodes spliced in to form each candidate tree (reused across candidates)
+        BitSet iBits = BitSet.newBitSet(leafArraySize);
+        iBits.set(leafIndex);
+        Node iLeaf = new Node();
+        iLeaf.setNr(leafIndex);
+        bits.put(iLeaf, iBits);
+        Node p = new Node();
+
+        List<Node> tgts = targets;
+        if (tgts == null) {
+            tgts = new ArrayList<>();
+            collectNonRoot(reduced.getRoot(), reduced.getRoot(), tgts);   // getNodesAsArray() may be uninitialised
+        }
+        Map<Node, Double> out = new HashMap<>(tgts.size() * 2);
+        for (Node x : tgts) {
+            out.put(x, scoreOneRegraft(reduced.getRoot(), x, leafIndex, iBits, iLeaf, p, bits, subScore));
+        }
+        return out;
+    }
+
+    /** Score the single tree formed by attaching the leaf above {@code x}: splice {@code p=(leaf, x)} into x's
+     *  edge, override the bits of {@code p} and the path {@code x.parent..root} to carry the leaf, run the
+     *  memoised scoreFresh, then restore everything (so {@code bits}/the tree are unchanged for the next target). */
+    private double scoreOneRegraft(Node root, Node x, int leafIndex, BitSet iBits, Node iLeaf, Node p,
+                                   Map<Node, BitSet> bits, Map<Node, Double> subScore) {
+        Node xp = x.getParent();
+        xp.removeChild(x);
+        xp.addChild(p);
+        p.addChild(iLeaf);
+        p.addChild(x);
+        BitSet pBits = (BitSet) bits.get(x).clone();
+        pBits.or(iBits);
+        bits.put(p, pBits);
+        List<Node> pathNodes = new ArrayList<>();
+        List<BitSet> pathSaved = new ArrayList<>();
+        for (Node a = xp; a != null; a = a.getParent()) {
+            pathNodes.add(a);
+            pathSaved.add(bits.get(a));
+            BitSet ab = (BitSet) bits.get(a).clone();
+            ab.or(iBits);
+            bits.put(a, ab);
+        }
+        double[] logp = {0.0};
+        scoreFreshMemo(root, bits, logp, leafIndex, subScore);
+        for (int q = 0; q < pathNodes.size(); q++) bits.put(pathNodes.get(q), pathSaved.get(q));
+        bits.remove(p);
+        xp.removeChild(p);
+        p.removeChild(iLeaf);
+        p.removeChild(x);
+        xp.addChild(x);
+        return logp[0];
+    }
+
+    /** {@code subScore[v]} = self-contained full-support score of v's subtree, computed bottom-up (mirrors a
+     *  standalone {@link #scoreFresh} of v). Only OBSERVED-clade nodes' values are ever read; novel-clade nodes get
+     *  0 (they only ever appear as region interior, never as a memoised recursion root). */
+    private double computeSubtreeScores(Node v, Map<Node, BitSet> bits, Map<Node, Double> subScore) {
+        if (v.isLeaf()) {
+            subScore.put(v, 0.0);
+            return 0.0;
+        }
+        Node c1 = v.getChildren().get(0), c2 = v.getChildren().get(1);
+        computeSubtreeScores(c1, bits, subScore);
+        computeSubtreeScores(c2, bits, subScore);
+        BitSet vb = bits.get(v), c1b = bits.get(c1), c2b = bits.get(c2);
+        double s;
+        if (isRed(vb, c1b, c2b)) {
+            Clade c = getClade(vb);
+            CladeReg reg = computeReg(c);
+            s = (reg.reservable() ? Math.log(1.0 - mu - reg.tail()) : 0.0)
+                    + rawLogCCP(c, c1b, c2b) + subScore.get(c1) + subScore.get(c2);
+        } else if (getClade(vb) != null) {
+            // observed clade, novel split: standalone region top
+            List<Node> boundary = new ArrayList<>();
+            collectRegion(v, bits, boundary);
+            s = regionScore(vb, getClade(vb), boundary.size(), boundary, bits);
+            for (Node b : boundary) s += subScore.get(b);
+        } else {
+            s = 0.0;   // novel clade: never read back
+        }
+        subScore.put(v, s);
+        return s;
+    }
+
+    /** Memoised {@link #scoreFresh}: identical pricing, but recursion into a subtree NOT containing the re-grafted
+     *  leaf returns the cached {@code subScore} instead of descending. Only ever entered on observed-clade nodes. */
+    private void scoreFreshMemo(Node v, Map<Node, BitSet> bits, double[] logp, int leafIndex,
+                                Map<Node, Double> subScore) {
+        if (v.isLeaf()) {
+            return;
+        }
+        Node c1 = v.getChildren().get(0), c2 = v.getChildren().get(1);
+        BitSet vb = bits.get(v), c1b = bits.get(c1), c2b = bits.get(c2);
+        if (isRed(vb, c1b, c2b)) {
+            Clade c = getClade(vb);
+            CladeReg reg = computeReg(c);
+            if (reg.reservable()) {
+                logp[0] += Math.log(1.0 - mu - reg.tail());
+            }
+            logp[0] += rawLogCCP(c, c1b, c2b);
+            memoRecurse(c1, bits, logp, leafIndex, subScore);
+            memoRecurse(c2, bits, logp, leafIndex, subScore);
+        } else {
+            List<Node> boundary = new ArrayList<>();
+            collectRegion(v, bits, boundary);
+            logp[0] += regionScore(vb, getClade(vb), boundary.size(), boundary, bits);
+            for (Node b : boundary) {
+                memoRecurse(b, bits, logp, leafIndex, subScore);
+            }
+        }
+    }
+
+    private void collectNonRoot(Node v, Node root, List<Node> out) {
+        if (v != root) out.add(v);
+        for (Node c : v.getChildren()) collectNonRoot(c, root, out);
+    }
+
+    private void memoRecurse(Node child, Map<Node, BitSet> bits, double[] logp, int leafIndex,
+                             Map<Node, Double> subScore) {
+        if (bits.get(child).get(leafIndex)) {
+            scoreFreshMemo(child, bits, logp, leafIndex, subScore);
+        } else {
+            logp[0] += subScore.get(child);
+        }
+    }
+
+    /** The blue-region contribution {@code (m - 2) * logEps(top) - logPath} (fallback {@code log(mu) - logPath}),
+     *  exactly as {@link #scoreFresh}'s else-branch (useStoredReg path). */
+    private double regionScore(BitSet vb, Clade top, int m, List<Node> boundary, Map<Node, BitSet> bits) {
+        double logPath = 0.0;
+        if (novelMode != NovelMode.FLAT) {
+            BitSet[] parts = new BitSet[m];
+            for (int i = 0; i < m; i++) parts[i] = bits.get(boundary.get(i));
+            logPath = Math.log(countAllNovelResolutions(vb, parts));
+        }
+        double logEps = computeReg(top).logEps();
+        return (logEps == Double.NEGATIVE_INFINITY) ? Math.log(mu) - logPath : (m - EXP_REDUCTION) * logEps - logPath;
+    }
+
+    /**
      * Probability of the given tree under the full-support model, {@code exp(getLogProbabilityOfTree)}.
      *
      * <p>Overrides {@link AbstractCCD#getProbabilityOfTree}, whose red-only CCP product is wrong here:

--- a/src/main/java/ccd/model/KRegCCD.java
+++ b/src/main/java/ccd/model/KRegCCD.java
@@ -1,0 +1,1832 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.algorithms.regularisation.KRegCCDParameterOptimiser;
+import ccd.algorithms.regularisation.NNIHeldOutComparison;
+import ccd.model.bitsets.BitSet;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Remco's "blue-region" CCD regularisation with <em>full support</em> (every tree
+ * gets nonzero probability), parameterised by the reserve depth {@code k}.
+ *
+ * <p>
+ * The split set is first widened by {@link RegCCD}'s CCD split expansion and
+ * additive-{@code alpha} smoothing, so a split among observed clades is always
+ * representable ("red", priced by its smoothed CCP). The only genuinely unseen
+ * structures are then <em>novel clades</em>. To score a tree we colour each
+ * internal node red (split in the expanded CCD) or blue (not — i.e. it involves a
+ * novel clade), cluster blue nodes into maximal regions, and price:
+ * <ul>
+ *   <li>each red node at clade {@code C} by {@code (1 - mu) * p(split|C)};</li>
+ *   <li>each blue region with top clade {@code C} and {@code j} novel clades by
+ *       {@code eps(C)^j / pathcount} — one {@code log eps} per novel clade.
+ *       {@code pathcount} is the number of all-novel resolutions of {@code C} into
+ *       the region's boundary subclades (a cheap subset-DP over the boundary).</li>
+ * </ul>
+ * A region with a boundary of {@code m} observed subclades has {@code m - 2} novel
+ * clades. Regions of <em>any</em> depth are scored, so any tree gets nonzero
+ * probability.
+ *
+ * <p>
+ * The single hyperparameter is {@code mu}, the per-clade escape probability.
+ * {@code eps(C)} is the root of {@code R(C) = sum_{j>=1} N_j(C) eps^j = mu}, where
+ * {@code N_j(C)} counts the region boundaries of {@code C} with {@code j} novel
+ * clades. Computing the exact reserve is #P-hard (a set-partition count over a
+ * non-laminar clade family), so we <em>decouple coverage from normalisation</em>:
+ * {@code eps} is solved from only the cheap low orders {@code j = 1..k} (boundaries
+ * {@code 3..k+2}; {@code N_1} is {@code O(m^2)}, {@code N_2} is {@code O(m^3)} in
+ * the number {@code m} of observed subclades), while regions of any depth are still
+ * scored with that {@code eps}. The omitted deep orders contribute {@code O(mu^2/m)}
+ * to the reserve — a rounding error — so this barely affects probabilities while
+ * keeping the model tractable and full-support. Reserve depth {@code k = 2} (the
+ * default) is recommended; an op-budget (scaled to the largest clade's N_1, overridable via
+ * {@code -Dkreg.enumOps})
+ * bounds even the low-order enumeration on pathological clades, and a clade with
+ * only deep regions climbs to its first nonzero order so {@code eps} stays positive.
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class KRegCCD extends RegCCD {
+
+    /**
+     * Per-clade enumeration-op budget: a clade's N_j enumeration is capped at this many steps so a
+     * genuine combinatorial blow-up (deep orders of a large clade) is bounded, while the low orders
+     * that set eps still complete.
+     *
+     * <p>The budget {@link #opsBudget} scales with the dataset: {@code OPS_BUDGET_FACTOR * m^2}, where
+     * {@code m} is the largest clade's observed-subclade count (the root's) and {@code m^2} is the cost
+     * of its order-1 (N_1) enumeration. So N_1 — which dominates eps — always completes regardless of
+     * dataset size, while the expensive deep orders stay capped. A flat {@code 1e9} default was ~1000x
+     * larger than needed on 129-taxon data (the reserve is unchanged from {@code ~m^2} upward). An
+     * explicit {@code -Dkreg.enumOps} value (accepts {@code 1e7} or {@code 10000000}) overrides the scaling.
+     */
+    private static final long OPS_BUDGET_FACTOR = 8L;
+    private static final long MIN_OPS_BUDGET = 2_000_000L;
+    private final long opsBudget;
+
+    /** Thrown internally when a single clade's N_j enumeration exceeds {@link #opsBudget}. */
+    private static final class BudgetExceeded extends RuntimeException {
+        BudgetExceeded() {
+            super(null, null, false, false);
+        }
+    }
+
+    private static final BudgetExceeded BUDGET_EXCEEDED = new BudgetExceeded();
+
+    /** Per-thread enumeration-step counter for the op budget. Thread-local so {@link #precomputeReserves}
+     *  can run clades in parallel: each clade's enumeration resets and accumulates its own thread's
+     *  counter (every enumeration routine is reset-then-walk within a single thread). */
+    private final ThreadLocal<long[]> enumOps = ThreadLocal.withInitial(() -> new long[1]);
+
+    /**
+     * Penalty exponent reduction: a boundary-{@code m} region (with {@code m-2}
+     * novel clades) is priced {@code eps^(m - EXP_REDUCTION)} = {@code eps^(#novel
+     * clades)}, i.e. one factor of {@code eps} per novel clade.
+     */
+    private static final int EXP_REDUCTION = 2;
+
+    /** Per-clade escape probability (reserved mass for unseen resolutions). */
+    private final double mu;
+
+    /** Additive-smoothing pseudocount for the split-expanded backbone (the fitted alpha). */
+    private final double alpha;
+
+    private final double log1mMu;
+
+    /**
+     * Reserve depth: include novel-clade orders 1..k (boundaries 3..k+2) when
+     * solving eps. Scoring is NOT truncated at this depth — every region is scored
+     * (full support), so coverage is independent of k.
+     */
+    private final int reserveBoundary; // = k + 2
+
+    /**
+     * How to correct for the omitted reserve tail (orders &gt; reserve depth) when
+     * discounting red splits by {@code 1 - mu - tail(C)}:
+     * <ul>
+     *   <li>{@link #NONE}: no correction ({@code tail = 0}); slightly
+     *       super-normalised (inflates held-out scores by the tail).</li>
+     *   <li>{@link #BOUND}: geometric upper bound on the tail; provably
+     *       sub-normalised (never inflates).</li>
+     *   <li>{@link #SAMPLED}: Knuth estimate of the actual tail; near-exactly
+     *       normalised (up to Monte-Carlo noise).</li>
+     * </ul>
+     */
+    public enum TailMode {NONE, BOUND, SAMPLED}
+
+    private final TailMode tailMode;
+
+    /**
+     * How novel-clade mass is weighted across the distinct novel resolutions of a blue region.
+     * <ul>
+     *   <li>{@link #SHARED}: the original scheme. Each observed-subclade boundary reserves a total
+     *       {@code eps^(m-2)}, shared evenly among its {@code pathcount} all-novel resolutions, so
+     *       a tree is priced {@code eps^(m-2) / pathcount} and the reserve sums boundary counts
+     *       {@code N_j}. This penalises novel clades clustered into one region (pathcount grows
+     *       ~{@code (2k+1)!!}).</li>
+     *   <li>{@link #FLAT}: every distinct novel resolution is priced {@code eps^(m-2)} directly
+     *       (no {@code /pathcount}), and the reserve sums tree counts {@code M_j = sum of pathcount
+     *       over boundaries}. This penalises each novel clade equally, independent of clustering.</li>
+     * </ul>
+     * Both are self-consistent, properly normalised priors (the reserve count and the per-tree
+     * normaliser are a matched pair); they agree at the single-novel-clade order and diverge only
+     * for clustered multi-clade regions.
+     */
+    public enum NovelMode {SHARED, FLAT}
+
+    private final NovelMode novelMode;
+
+    /** Default novel-clade weighting (clustering-neutral). */
+    public static final NovelMode DEFAULT_NOVEL_MODE = NovelMode.FLAT;
+
+    /**
+     * Largest {@code mu} at which the depth-{@code k} reserve approximation stays reliable. Above
+     * it the omitted reserve tail grows ~{@code mu^3} and the un-corrected (NONE) inflation becomes
+     * material (&gt; ~0.01 nat/tree), so the model should not be operated — nor its parameters
+     * searched (see {@link ccd.algorithms.regularisation.KRegCCDParameterOptimiser}) — beyond it.
+     */
+    public static final double MU_RELIABLE_MAX = 0.05;
+
+    /** mu above which the un-corrected inflation becomes material (&gt; ~0.01 nat). */
+    private static final double MU_WARN_THRESHOLD = MU_RELIABLE_MAX;
+
+    /** Knuth samples per order when estimating the tail (SAMPLED mode). */
+    private static final int TAIL_SAMPLES = 1000;
+
+    /** Below this, the bounded tail is negligible, so SAMPLED skips the sampling. */
+    private static final double TAIL_SAMPLE_THRESHOLD = 1e-5;
+
+    private final java.util.Random rng = new java.util.Random(12345);
+
+    /**
+     * Fidelity of {@link #sampleTree()} relative to the full-support score
+     * ({@link #getLogProbabilityOfTree}).
+     * <ul>
+     *   <li>{@link #SELF_CONSISTENT}: escape with probability {@code mu} and draw blue regions
+     *       only up to the computed novelty orders (1..k, whose weights {@code N_j eps^j} sum to
+     *       {@code mu} by the eps-solve). This is exactly {@code exp(score)} with the tail set to
+     *       zero; regions deeper than {@code k} (mass ~{@code mu^3}) are never produced.</li>
+     *   <li>{@link #FULL_SUPPORT}: escape with probability {@code mu + tail} and additionally draw
+     *       the leading tail orders ({@code k+1, k+2}) via the Knuth estimator, so frequencies
+     *       approach {@code exp(getLogProbabilityOfTree)} up to an {@code O(mu^4)} truncation of
+     *       orders beyond {@code k+2}.</li>
+     * </ul>
+     * In both modes a region's boundary parts are resolved with an observed (red) split, which
+     * makes the sampled blue regions <em>maximal</em> — matching the score's region decomposition
+     * (and avoiding the over-counting a free recursion would cause). The sampling distribution is
+     * exact whenever no boundary part is itself a reserving clade (always true for trees up to ~5
+     * taxa); for larger trees it deviates from {@code exp(score)} by the boundary parts' own
+     * {@code (1 - mu - tail)} reservation, an {@code O(mu)}-per-reserving-boundary-part effect.
+     */
+    public enum SamplingFidelity {SELF_CONSISTENT, FULL_SUPPORT}
+
+    private SamplingFidelity samplingFidelity = SamplingFidelity.SELF_CONSISTENT;
+
+    /** Reservoir state for {@link #sampleBoundary}: count of valid boundaries seen so far. */
+    private int boundarySeen;
+    private double boundaryWeightSeen; // weighted-reservoir accumulator for FLAT boundary sampling
+    /** Reservoir state for {@link #sampleBoundary}: the boundary currently selected. */
+    private BitSet[] boundaryPick;
+
+    /**
+     * Strictly-positive fallback increment for novel-node heights when the region top is not
+     * strictly above a boundary part (e.g. common-ancestor-height non-monotonicity).
+     */
+    private static final double NOVEL_HEIGHT_EPS = 1e-8;
+
+    /**
+     * Per-clade reserve info: whether C reserves mu, log eps(C) (NEGATIVE_INFINITY
+     * if nothing computable), and the tail correction to subtract from (1 - mu).
+     *
+     * <p>{@code nCounts} caches the per-boundary partition counts used to solve eps:
+     * {@code nCounts[m]} is N_{m-2}(C) (the number of boundary-m partitions admitting an
+     * all-novel resolution), for boundaries {@code 3..lastBoundary}. The sampler reuses these
+     * to draw a region's novelty order j with probability proportional to N_j eps^j, exactly
+     * matching the score (the same counts that pinned eps). {@code null}/{@code 0} when C is
+     * not reservable.
+     */
+    private record CladeReg(boolean reservable, double logEps, double tail,
+                            int[] nCounts, int lastBoundary) {
+    }
+
+    private final Map<Clade, CladeReg> regCache = new ConcurrentHashMap<>();
+
+    /**
+     * Default per-clade escape probability used when a tool builds a KRegCCD without
+     * specifying one (e.g. via {@link CCDType#KRegCCD}); the RSV2 operating point.
+     */
+    public static final double DEFAULT_MU = 0.01;
+    /**
+     * Default additive-smoothing pseudocount for the split-expanded backbone (shared with
+     * {@link RegCCD}'s default).
+     */
+    public static final double DEFAULT_ALPHA = 0.4;
+    /** Default reserve depth k. */
+    public static final int DEFAULT_RESERVE_DEPTH = 2;
+
+    /**
+     * Default variant: reserve depth k = 2 (eps from the one- and two-novel-clade
+     * orders), full-support scoring.
+     *
+     * @param trees  training trees (post burn-in)
+     * @param burnin fraction discarded as burn-in (0.0 if already removed)
+     * @param mu     per-clade escape probability, in (0, 1)
+     * @param alpha  additive-smoothing pseudocount for the split-expanded backbone
+     */
+    public KRegCCD(List<Tree> trees, double burnin, double mu, double alpha) {
+        this(trees, burnin, mu, alpha, 2);
+    }
+
+    /**
+     * @param k reserve depth (see below); tail bound correction on.
+     */
+    public KRegCCD(List<Tree> trees, double burnin, double mu, double alpha, int k) {
+        this(trees, burnin, mu, alpha, k, TailMode.BOUND);
+    }
+
+    /**
+     * @param trees    training trees (post burn-in)
+     * @param burnin   fraction discarded as burn-in (0.0 if already removed)
+     * @param mu       per-clade escape probability, in (0, 1)
+     * @param alpha    additive-smoothing pseudocount for the split-expanded backbone
+     * @param k        reserve depth: include novel-clade orders {@code 1..k} when
+     *                 solving {@code eps} (>= 1). Scoring is NOT truncated at
+     *                 {@code k}, so coverage is full regardless; {@code k} only
+     *                 affects accuracy.
+     * @param tailMode how to correct for the omitted reserve tail (see {@link TailMode})
+     */
+    public KRegCCD(List<Tree> trees, double burnin, double mu, double alpha, int k,
+                   TailMode tailMode) {
+        this(trees, burnin, mu, alpha, k, tailMode, DEFAULT_NOVEL_MODE);
+    }
+
+    /**
+     * @param novelMode how novel-clade mass is weighted across resolutions (see {@link NovelMode})
+     */
+    public KRegCCD(List<Tree> trees, double burnin, double mu, double alpha, int k,
+                   TailMode tailMode, NovelMode novelMode) {
+        super(trees, burnin, false); // plain CCD1; split expansion + smoothing applied below
+        validateParams(mu, k, alpha);
+        this.mu = mu;
+        this.alpha = alpha;
+        this.log1mMu = Math.log(1.0 - mu);
+        this.reserveBoundary = k + 2; // boundary size = novel clades + 2
+        this.tailMode = tailMode;
+        this.novelMode = novelMode;
+        expandRegCCD();
+        regulariseRegCCD(alpha);
+        this.opsBudget = computeOpsBudget();
+    }
+
+    /**
+     * Constructor from a burn-in-free tree set (used by the CCD tools, e.g. {@link CCDType#KRegCCD}
+     * via {@code CCDToolUtil}). Mirrors the {@link List}-based constructor: builds the plain CCD1
+     * backbone, then split-expands and additively smooths it, leaving eps to be solved per clade
+     * on demand.
+     *
+     * @param treeSet  trees without burn-in whose distribution is approximated
+     * @param mu       per-clade escape probability, in (0, 1)
+     * @param alpha    additive-smoothing pseudocount for the split-expanded backbone
+     * @param k        reserve depth (see the {@link List}-based constructor)
+     * @param tailMode how to correct for the omitted reserve tail (see {@link TailMode})
+     */
+    public KRegCCD(TreeAnnotator.TreeSet treeSet, double mu, double alpha, int k, TailMode tailMode) {
+        this(treeSet, mu, alpha, k, tailMode, DEFAULT_NOVEL_MODE);
+    }
+
+    /**
+     * @param novelMode how novel-clade mass is weighted across resolutions (see {@link NovelMode})
+     */
+    public KRegCCD(TreeAnnotator.TreeSet treeSet, double mu, double alpha, int k, TailMode tailMode,
+                   NovelMode novelMode) {
+        super(treeSet, false); // plain CCD1 from the tree set; expansion + smoothing applied below
+        validateParams(mu, k, alpha);
+        this.mu = mu;
+        this.alpha = alpha;
+        this.log1mMu = Math.log(1.0 - mu);
+        this.reserveBoundary = k + 2;
+        this.tailMode = tailMode;
+        this.novelMode = novelMode;
+        expandRegCCD();
+        regulariseRegCCD(alpha);
+        this.opsBudget = computeOpsBudget();
+    }
+
+    /**
+     * Builds a KRegCCD on {@code trees} with {@code (alpha, mu)} selected by maximising
+     * cross-validated held-out tree log-probability (see {@link KRegCCDParameterOptimiser}),
+     * rather than using the fixed {@link #DEFAULT_MU}/{@link #DEFAULT_ALPHA}. Reserve depth is
+     * {@link #DEFAULT_RESERVE_DEPTH} and the tail correction is {@link TailMode#BOUND}.
+     *
+     * @param trees the trees the model is built on and cross-validated over
+     * @param folds number of cross-validation folds
+     */
+    public static KRegCCD withOptimisedParameters(List<Tree> trees, int folds) {
+        KRegCCDParameterOptimiser.Params p = KRegCCDParameterOptimiser.optimise(trees, folds, NNIHeldOutComparison.FoldAssignment.CONTIGUOUS);
+        return new KRegCCD(trees, 0.0, p.mu(), p.alpha(), DEFAULT_RESERVE_DEPTH, TailMode.BOUND);
+    }
+
+    /** As {@link #withOptimisedParameters(List, int)} with {@link KRegCCDParameterOptimiser#DEFAULT_FOLDS} folds. */
+    public static KRegCCD withOptimisedParameters(List<Tree> trees) {
+        return withOptimisedParameters(trees, KRegCCDParameterOptimiser.DEFAULT_FOLDS);
+    }
+
+    public static KRegCCD withOptimisedMu(List<Tree> trees) {
+        KRegCCDParameterOptimiser.MuResult r =
+                KRegCCDParameterOptimiser.optimiseMu(trees, KRegCCDParameterOptimiser.DEFAULT_FOLDS,
+                        NNIHeldOutComparison.FoldAssignment.CONTIGUOUS, DEFAULT_ALPHA);
+
+        System.out.println("Optimised mu = " + r.mu() + ", held-out logP = " + r.heldOutLogProb());
+
+        return new KRegCCD(trees, 0.0, r.mu(), DEFAULT_ALPHA, DEFAULT_RESERVE_DEPTH, TailMode.BOUND);
+    }
+
+    /** The additive-smoothing pseudocount alpha this model was built/fitted with. */
+    public double getAlpha() {
+        return alpha;
+    }
+
+    /** The per-clade escape probability mu this model was built/fitted with. */
+    public double getMu() {
+        return mu;
+    }
+
+    private static void validateParams(double mu, int k, double alpha) {
+        if (mu <= 0 || mu >= 1) {
+            throw new IllegalArgumentException("mu must be in (0, 1), got " + mu);
+        }
+        if (k < 1) {
+            throw new IllegalArgumentException("reserve depth k must be >= 1, got " + k);
+        }
+        if (Double.isNaN(alpha)) {
+            throw new IllegalArgumentException("KRegCCD requires split expansion (finite alpha)");
+        }
+        if (mu > MU_WARN_THRESHOLD) {
+            System.err.println("WARNING: KRegCCD mu = " + mu + " > " + MU_WARN_THRESHOLD
+                    + "; the reserve-tail inflation grows ~mu^3 and becomes material here "
+                    + "(~" + String.format("%.2g", Math.pow(mu / 0.05, 3) * 0.01)
+                    + " nat/tree at this mu). Use a smaller mu, or TailMode.BOUND/SAMPLED.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "KRegCCD [mu = " + mu + ", reserve depth k = " + (reserveBoundary - 2)
+                + ", tail=" + tailMode + ", novel=" + novelMode + ", full support, split-expanded]";
+    }
+
+    /* ----------------------------------------------------------------------
+     * Tree scoring
+     * ------------------------------------------------------------------- */
+
+    @Override
+    public double getLogProbabilityOfTree(Tree tree) {
+        Map<Node, BitSet> bits = new HashMap<>();
+        computeBits(tree.getRoot(), bits);
+        double[] logp = new double[]{0.0};
+        scoreFresh(tree.getRoot(), bits, logp, mu, true);
+        return logp[0];
+    }
+
+    /**
+     * Full-support log-probability of a tree at an arbitrary escape probability {@code scoreMu},
+     * reusing this model's ({@code mu}-independent) clade/split backbone and cached per-clade
+     * {@code N_j} counts. Scored with no reserve-tail correction (tail = 0, i.e.
+     * {@link TailMode#NONE} semantics), which is the objective used to select {@code mu}. This
+     * lets a parameter optimiser evaluate many {@code mu} values on one trained backbone without
+     * rebuilding — {@code eps(C)} is just re-solved from the cached counts. For
+     * {@code scoreMu == mu} and a {@code NONE}-built model it equals {@link #getLogProbabilityOfTree(Tree)}.
+     */
+    public double getLogProbabilityOfTree(Tree tree, double scoreMu) {
+        if (scoreMu <= 0 || scoreMu >= 1) {
+            throw new IllegalArgumentException("scoreMu must be in (0, 1), got " + scoreMu);
+        }
+        Map<Node, BitSet> bits = new HashMap<>();
+        computeBits(tree.getRoot(), bits);
+        double[] logp = new double[]{0.0};
+        scoreFresh(tree.getRoot(), bits, logp, scoreMu, false);
+        return logp[0];
+    }
+
+    /**
+     * Probability of the given tree under the full-support model, {@code exp(getLogProbabilityOfTree)}.
+     *
+     * <p>Overrides {@link AbstractCCD#getProbabilityOfTree}, whose red-only CCP product is wrong here:
+     * it returns 0 for any tree containing a novel clade (this model gives every tree nonzero mass) and
+     * omits the per-clade {@code (1 - mu)} escape discount even for fully observed trees. Note this can
+     * underflow to 0 for large trees; use {@link #getLogProbabilityOfTree(Tree)} when that matters.
+     */
+    @Override
+    public double getProbabilityOfTree(Tree tree) {
+        return Math.exp(getLogProbabilityOfTree(tree));
+    }
+
+    /**
+     * Always {@code true}: KRegCCD is full support, so every tree on this taxon set has nonzero
+     * probability. Overrides the inherited {@code getProbabilityOfTree(tree) > 0} test, which would
+     * both inherit the red-only bug above and report a false negative when a large tree's probability
+     * underflows to 0.
+     */
+    @Override
+    public boolean containsTree(Tree tree) {
+        return true;
+    }
+
+    /**
+     * Number of internal clades of {@code tree} that are not present in this CCD's observed clade
+     * set (the novel-clade count = the total {@code m-2} over the tree's blue regions). This is the
+     * exponent that the per-region {@code eps} factors are raised to, and is mode-independent (it
+     * depends only on the observed backbone, not on SHARED/FLAT weighting). Useful for bucketing
+     * held-out trees by how much novel (clustered) structure they carry.
+     */
+    public int novelCladeCount(Tree tree) {
+        Map<Node, BitSet> bits = new HashMap<>();
+        computeBits(tree.getRoot(), bits);
+        int count = 0;
+        for (Node v : tree.getNodesAsArray()) {
+            if (v.isLeaf()) {
+                continue;
+            }
+            if (getClade(bits.get(v)) == null) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /* ----------------------------------------------------------------------
+     * MAP tree (discounted DP)
+     *
+     * The inherited max-probability DP (AbstractCCD/Clade.getMaxSubtreeLogCCP) maximises only the
+     * sum of observed log-CCPs -- the red-only backbone. It is wrong for a full-support model in two
+     * ways: (1) it OMITS the per-clade red discount log(1 - mu - tail(C)) that scoreFresh charges at
+     * every reservable clade, so its returned max probability is inflated; and (2) because that
+     * discount is incurred once per reservable internal clade and reservability differs between
+     * topologies, the discount can change which resolution is optimal -- so the max-CCP topology need
+     * not be the full-support MAP. We replace it with a discounted DP over the same observed-clade DAG:
+     *
+     *   D(c)  = disc(c) + max_p [ logCCP(c -> L,R) + D(L) + D(R) ],   D(leaf) = 0
+     *   disc(c) = reservable(c) ? log(1 - mu - tail(c)) : 0
+     *
+     * which is exactly scoreFresh's score of an all-red tree, maximised. Escapes are never taken: a
+     * blue region contributes eps^(m-2)/pathcount (with eps << mu), strictly less than the red
+     * alternative's (1 - mu) * ccp at the operating mu (<= MU_RELIABLE_MAX), so the global MAP is the
+     * best all-red tree this DP finds. getMAPTree follows the same argmax partitions (via the MAP
+     * branch of getPartitionBasedOnStrategy), so getMaxLogTreeProbability() ==
+     * getLogProbabilityOfTree(getMAPTree()) by construction.
+     * ------------------------------------------------------------------- */
+
+    private Map<Clade, Double> mapLogProbMemo;
+    private Map<Clade, CladePartition> mapPartitionMemo;
+
+    /**
+     * Computes the discounted MAP DP over all clades (children before parents) and caches, per
+     * clade, the best all-red subtree log-probability and the argmax partition. Idempotent.
+     */
+    private void computeDiscountedMap() {
+        if (mapLogProbMemo != null) {
+            return;
+        }
+        Map<Clade, Double> logProb = new HashMap<>();
+        Map<Clade, CladePartition> argmax = new HashMap<>();
+        List<Clade> clades = new ArrayList<>(getClades());
+        clades.sort((a, b) -> Integer.compare(a.size(), b.size()));
+        for (Clade c : clades) {
+            if (c.isLeaf()) {
+                logProb.put(c, 0.0);
+                continue;
+            }
+            double best = Double.NEGATIVE_INFINITY;
+            CladePartition bestPartition = null;
+            for (CladePartition p : c.getPartitions()) {
+                Clade[] ch = p.getChildClades();
+                double v = p.getLogCCP() + logProb.get(ch[0]) + logProb.get(ch[1]);
+                if (v > best) { // first-wins on ties: getPartitions() order is deterministic
+                    best = v;
+                    bestPartition = p;
+                }
+            }
+            CladeReg reg = computeReg(c);
+            double disc = reg.reservable() ? Math.log(1.0 - mu - reg.tail()) : 0.0;
+            logProb.put(c, disc + best);
+            argmax.put(c, bestPartition);
+        }
+        mapLogProbMemo = logProb;
+        mapPartitionMemo = argmax;
+    }
+
+    /**
+     * Log-probability of the most likely tree under the full-support model: the discounted DP value
+     * at the root (see the section comment above). Overrides the inherited red-only maximum, which
+     * omits the per-clade {@code (1 - mu - tail)} escape discount and so overstates the maximum.
+     */
+    @Override
+    public double getMaxLogTreeProbability() {
+        computeDiscountedMap();
+        return mapLogProbMemo.get(getRootClade());
+    }
+
+    /**
+     * Routes the MAP partition selection through the discounted DP so {@link #getMAPTree()} returns
+     * the full-support MAP tree (whose log-probability is {@link #getMaxLogTreeProbability()}), not
+     * the red-only max-CCP tree. Other strategies keep the inherited behaviour.
+     */
+    @Override
+    protected CladePartition getPartitionBasedOnStrategy(Clade clade, SamplingStrategy samplingStrategy) {
+        if (samplingStrategy == SamplingStrategy.MAP) {
+            computeDiscountedMap();
+            return mapPartitionMemo.get(clade);
+        }
+        return super.getPartitionBasedOnStrategy(clade, samplingStrategy);
+    }
+
+    /* ----------------------------------------------------------------------
+     * Entropy
+     *
+     * The inherited CCD entropy (AbstractCCD.getEntropy / getEntropyLewis, the
+     * Lewis et al. 2016 recursion) sums only over observed clade partitions and
+     * treats their CCPs as a complete distribution. That is the entropy of the
+     * renormalised red-only backbone (the smoothed, split-expanded CCD1) -- it
+     * silently drops the escape mass mu, the blue regions, and the whole
+     * novel-clade support, so it is the WRONG quantity for the full-support
+     * KRegCCD. We provide two estimators of the real thing instead:
+     *
+     *  - getEntropyMonteCarlo: a plug-in average -mean(log P) over trees drawn
+     *    from the model's own sampler. Simple, public-API only, with a reported
+     *    standard error; bias is the O(mu)-per-reserving-boundary-part gap the
+     *    sampler already carries (negligible at the operating mu <= 0.05).
+     *
+     *  - getEntropyRecursive: a generalisation of the Lewis recursion to the
+     *    escape mixture. Exact for the self-consistent escape distribution
+     *    (tail = 0, escape mass exactly mu, region orders 1..k), modulo the same
+     *    op-budget truncation the rest of the model uses; far lower variance.
+     *
+     * {@link #getEntropy()} mirrors {@link #sampleTree()}: it reports the entropy of whichever
+     * distribution the sampler would draw at the current {@link SamplingFidelity} -- the exact
+     * recursion for SELF_CONSISTENT, the Monte-Carlo plug-in for FULL_SUPPORT (whose reserve tail
+     * has no cheap closed form). Under SELF_CONSISTENT both estimators target the same normalised,
+     * tail-excluded distribution, so they are directly comparable; on small trees, where the model
+     * normalises exactly, they agree with the brute-force entropy.
+     * ------------------------------------------------------------------- */
+
+    /**
+     * Number of sampled trees used by {@link #getEntropy()} (the default Monte-Carlo path is
+     * not used; the recursion is). Kept for the convenience overload.
+     */
+    public static final int DEFAULT_ENTROPY_SAMPLES = 100_000;
+
+    /**
+     * The inherited Lewis-recursion entropy is invalid for a full-support model (it ignores escape
+     * mass and novel clades). Use {@link #getEntropy()} (the generalised recursion) or
+     * {@link #getEntropyMonteCarlo(int)} instead.
+     */
+    @Override
+    public double getEntropyLewis() {
+        throw new UnsupportedOperationException(
+                "The Lewis-recursion entropy only covers observed clade partitions and so omits "
+                        + "KRegCCD's escape mass and novel-clade support. Use getEntropy() (the "
+                        + "generalised recursion) or getEntropyMonteCarlo(samples).");
+    }
+
+    /**
+     * Entropy (in nats) of the KRegCCD topology distribution that {@link #sampleTree()} would draw
+     * from at the current {@link SamplingFidelity} -- so the reported entropy always matches the
+     * distribution the sampler produces. Like the sampler, the mode is read from
+     * {@link #setSamplingFidelity}:
+     * <ul>
+     *   <li>{@link SamplingFidelity#SELF_CONSISTENT}: the normalised distribution with escape mass
+     *       exactly {@code mu} and blue regions only up to reserve depth {@code k}. Computed by the
+     *       exact, deterministic recursion {@link #getEntropyRecursive()}.</li>
+     *   <li>{@link SamplingFidelity#FULL_SUPPORT}: the full model, including the reserve tail
+     *       (regions deeper than {@code k}). The tail is the same #P-hard quantity the sampler
+     *       Knuth-estimates, so there is no cheap exact recursion for it; this falls back to the
+     *       Monte-Carlo plug-in {@link #getEntropyMonteCarlo(int)} ({@link #DEFAULT_ENTROPY_SAMPLES}
+     *       samples), exactly as full-support <em>sampling</em> relies on the Knuth tail.</li>
+     * </ul>
+     * For the two estimators to be mutually consistent (and the Monte-Carlo path unbiased), pair the
+     * fidelity with the matching {@link TailMode} the sampler expects -- {@code SELF_CONSISTENT} with
+     * {@link TailMode#NONE}, {@code FULL_SUPPORT} with {@link TailMode#SAMPLED} -- so the sampler's
+     * red discount {@code (1 - mu - tail)} matches its escape mass. Overrides the inherited
+     * observed-only formula, which is wrong for a full-support model.
+     */
+    @Override
+    public double getEntropy() {
+        return switch (samplingFidelity) {
+            case SELF_CONSISTENT -> getEntropyRecursive();
+            case FULL_SUPPORT -> {
+                if (tailMode == TailMode.NONE) {
+                    System.err.println("WARNING: getEntropy() in FULL_SUPPORT fidelity on a "
+                            + "TailMode.NONE model is biased: the sampler escapes with mu + tail but "
+                            + "the red discount omits the tail (super-normalised). Build with "
+                            + "TailMode.SAMPLED for an unbiased full-support entropy.");
+                }
+                yield getEntropyMonteCarlo(DEFAULT_ENTROPY_SAMPLES)[0];
+            }
+        };
+    }
+
+    /**
+     * Monte-Carlo plug-in estimate of the entropy: draw {@code samples} trees from the model's
+     * sampler and average their negative log-probability,
+     * {@code H = -mean(log P(T_s))}. Returns {@code {entropy, standardError}} (both in nats), the
+     * standard error being {@code sd(log P) / sqrt(samples)}.
+     *
+     * <p>This estimates {@code -E_Q[log P]} where {@code Q} is the sampler's distribution and
+     * {@code P} the scored distribution; the two coincide except for the sampler's
+     * {@code O(mu)}-per-reserving-boundary-part reservation (the same gap documented on
+     * {@link SamplingFidelity}), so on trees small enough that no boundary part reserves (P == Q,
+     * exactly normalised) this is an unbiased estimate of the true entropy. Set the RNG via
+     * {@link #setRandom} for reproducibility; uses the current {@link SamplingFidelity}.
+     */
+    public double[] getEntropyMonteCarlo(int samples) {
+        if (samples < 2) {
+            throw new IllegalArgumentException("need at least 2 samples for a standard error");
+        }
+        double sumLogP = 0.0;
+        double sumLogP2 = 0.0;
+        for (int s = 0; s < samples; s++) {
+            Tree t = sampleTree(HeightSettingStrategy.None);
+            double logp = (Double) t.getRoot().getMetaData(LOG_PROB_SUBTREE_KEY);
+            sumLogP += logp;
+            sumLogP2 += logp * logp;
+        }
+        double meanLogP = sumLogP / samples;
+        double varLogP = Math.max(0.0, sumLogP2 / samples - meanLogP * meanLogP);
+        double stdErr = Math.sqrt(varLogP / samples);
+        return new double[]{-meanLogP, stdErr};
+    }
+
+    /**
+     * Generalised Lewis recursion for the full-support entropy. The KRegCCD distribution is
+     * generated by the same recursive branching process the sampler walks, so entropy decomposes by
+     * the chain rule over the observed-clade DAG. At a reservable clade {@code C} the immediate
+     * decision is a mixture: with probability {@code 1 - mu} an observed (red) split (weighted by
+     * its CCP), and with probability {@code mu} an escape into a blue region. Writing
+     * {@code H_free(C)} for the entropy of the subtree generated when {@code C} may escape and
+     * {@code H_red(C)} for when {@code C} is forced to take an observed split (a blue region's
+     * boundary part), with escape mass {@code mu} and {@code eps = eps(C)}:
+     * <pre>
+     *   H_red(C)  = sum_(L,R) ccp(L,R) * ( -log ccp(L,R) + H_free(L) + H_free(R) )
+     *   H_free(C) = (1 - mu) * ( -log(1 - mu) + H_red(C) )                       // red branch
+     *             + (-log eps) * sum_m (m-2) * N_m * eps^(m-2)                   // blue self-information
+     *             + sum_(regions) P(region) * sum_i H_red(B_i)                   // blue children (forced red)
+     * </pre>
+     * The red part and the blue self-information are exact (finite sums over the computed orders).
+     * The blue-children term is computed exactly by enumerating the same canonical boundaries the
+     * reserve uses (FLAT weights each boundary by its pathcount, SHARED by one), bounded by the same
+     * op-budget; for SHARED the per-boundary {@code log pathcount} self-information is accumulated in
+     * the same pass. Clades are processed in increasing size so every child and boundary part is
+     * already memoised when a clade is reached (the enumeration then does no nested re-entry).
+     *
+     * @return the entropy (in nats) of the self-consistent (tail = 0, escape mass {@code mu})
+     * KRegCCD distribution
+     */
+    public double getEntropyRecursive() {
+        Map<Clade, Double> freeMemo = new HashMap<>();
+        Map<Clade, Double> redMemo = new HashMap<>();
+        List<Clade> clades = new ArrayList<>(getClades());
+        clades.sort((a, b) -> Integer.compare(a.size(), b.size()));
+        for (Clade c : clades) {
+            entropyRedForced(c, freeMemo, redMemo);
+            entropyFree(c, freeMemo, redMemo);
+        }
+        return freeMemo.getOrDefault(getRootClade(), 0.0);
+    }
+
+    /**
+     * Entropy of the subtree generated at {@code c} when {@code c} may escape (the root, or a red
+     * child of another node). Assumes all strictly-smaller clades are already memoised.
+     */
+    private double entropyFree(Clade c, Map<Clade, Double> freeMemo, Map<Clade, Double> redMemo) {
+        if (c.isLeaf()) {
+            return 0.0;
+        }
+        Double cached = freeMemo.get(c);
+        if (cached != null) {
+            return cached;
+        }
+        CladeReg reg = computeReg(c);
+        double h;
+        if (!reg.reservable()) {
+            h = entropyRedForced(c, freeMemo, redMemo); // no escape mass: pure observed-split node
+        } else {
+            double eps = Math.exp(reg.logEps());
+            int[] n = reg.nCounts();
+            int last = reg.lastBoundary();
+            // self-consistent order weights w[m] = N_m * eps^(m-2), m = 3..last; sum == mu by the
+            // eps-solve. "blueSelfInfoSum" accumulates sum_m (m-2) w[m] for the blue self-information.
+            double escapeMass = 0.0;
+            double blueSelfInfoSum = 0.0;
+            for (int m = 3; m <= last; m++) {
+                if (n[m] > 0) {
+                    double w = n[m] * Math.pow(eps, m - EXP_REDUCTION);
+                    escapeMass += w;
+                    blueSelfInfoSum += (m - EXP_REDUCTION) * w;
+                }
+            }
+            double redMass = 1.0 - escapeMass;
+            double redContribution = redMass * (-Math.log(redMass) + entropyRedForced(c, freeMemo, redMemo));
+            BlueTerms blue = blueContribution(c, reg, eps, freeMemo, redMemo);
+            // FLAT: blue self-information is exactly -log(eps) * sum_m (m-2) w[m]. SHARED adds the
+            // per-region -log(1/pathcount) = +log(pathcount) self-information collected by the enumeration.
+            double blueSelfInfo = -reg.logEps() * blueSelfInfoSum + blue.extraLogPc();
+            h = redContribution + blueSelfInfo + blue.childEntropy();
+        }
+        freeMemo.put(c, h);
+        return h;
+    }
+
+    /**
+     * Entropy of the subtree generated at {@code c} when {@code c} is forced to take an observed
+     * (red) split -- i.e. as a blue region's boundary part: split ~ CCP, children free. Assumes all
+     * strictly-smaller clades are already memoised.
+     */
+    private double entropyRedForced(Clade c, Map<Clade, Double> freeMemo, Map<Clade, Double> redMemo) {
+        if (c.isLeaf()) {
+            return 0.0;
+        }
+        Double cached = redMemo.get(c);
+        if (cached != null) {
+            return cached;
+        }
+        double h = 0.0;
+        for (CladePartition p : c.getPartitions()) {
+            double ccp = p.getCCP();
+            Clade[] ch = p.getChildClades();
+            h += ccp * (-p.getLogCCP()
+                    + entropyFree(ch[0], freeMemo, redMemo) + entropyFree(ch[1], freeMemo, redMemo));
+        }
+        redMemo.put(c, h);
+        return h;
+    }
+
+    /**
+     * The two enumeration-derived parts of a clade's blue (escape) entropy contribution:
+     * {@code childEntropy} = sum over regions of P(region) * sum_i H_red(boundary part i), and
+     * {@code extraLogPc} = the SHARED-only per-region +log(pathcount) self-information (0 for FLAT).
+     */
+    private record BlueTerms(double childEntropy, double extraLogPc) {
+    }
+
+    /**
+     * Enumerates the canonical boundaries of {@code c} (orders 3..lastBoundary) into observed
+     * subclades admitting an all-novel resolution -- the same enumeration the reserve uses -- and
+     * accumulates the blue-region entropy terms exactly. Bounded by the per-clade op-budget.
+     */
+    private BlueTerms blueContribution(Clade c, CladeReg reg, double eps,
+                                       Map<Clade, Double> freeMemo, Map<Clade, Double> redMemo) {
+        List<Clade> subs = observedSubclades(c);
+        BitSet cBits = c.getCladeInBits();
+        double[] acc = new double[2]; // [0] childEntropy, [1] extraLogPc (SHARED)
+        enumOps.get()[0] = 0;
+        try {
+            for (int m = 3; m <= reg.lastBoundary(); m++) {
+                blueWalk(cBits, subs, m, 0, BitSet.newBitSet(leafArraySize), new ArrayList<>(m),
+                        eps, acc, freeMemo, redMemo);
+            }
+        } catch (BudgetExceeded e) {
+            // deeper boundaries omitted (negligible, like the reserve tail); same guard as countNj
+        }
+        return new BlueTerms(acc[0], acc[1]);
+    }
+
+    private void blueWalk(BitSet cBits, List<Clade> subs, int m, int startIdx, BitSet used,
+                          List<BitSet> chosen, double eps, double[] acc,
+                          Map<Clade, Double> freeMemo, Map<Clade, Double> redMemo) {
+        if (++enumOps.get()[0] > opsBudget) {
+            throw BUDGET_EXCEEDED;
+        }
+        if (chosen.size() == m - 1) {
+            BitSet last = (BitSet) cBits.clone();
+            last.andNot(used);
+            if (last.cardinality() == 0 || getClade(last) == null) {
+                return;
+            }
+            if (compareBitSets(chosen.get(chosen.size() - 1), last) >= 0) {
+                return;
+            }
+            BitSet[] parts = new BitSet[m];
+            for (int i = 0; i < m - 1; i++) {
+                parts[i] = chosen.get(i);
+            }
+            parts[m - 1] = last;
+            int pc = countAllNovelResolutions(cBits, parts);
+            if (pc <= 0) {
+                return;
+            }
+            double epsPow = Math.pow(eps, m - EXP_REDUCTION);
+            double sumChildH = 0.0;
+            for (BitSet pb : parts) {
+                sumChildH += entropyRedForced(getClade(pb), freeMemo, redMemo); // memoised lookup
+            }
+            // mass on this boundary: pathcount * eps^(m-2) [FLAT] or eps^(m-2) [SHARED]
+            double boundaryMass = (novelMode == NovelMode.FLAT) ? pc * epsPow : epsPow;
+            acc[0] += boundaryMass * sumChildH;
+            if (novelMode == NovelMode.SHARED) {
+                acc[1] += epsPow * Math.log(pc);
+            }
+            return;
+        }
+        for (int i = startIdx; i < subs.size(); i++) {
+            BitSet pb = subs.get(i).getCladeInBits();
+            if (pb.intersects(used)) {
+                continue;
+            }
+            chosen.add(pb);
+            BitSet newUsed = (BitSet) used.clone();
+            newUsed.or(pb);
+            blueWalk(cBits, subs, m, i + 1, newUsed, chosen, eps, acc, freeMemo, redMemo);
+            chosen.remove(chosen.size() - 1);
+        }
+    }
+
+    /* ----------------------------------------------------------------------
+     * Calibration: total model mass on trees with at least one novel clade
+     * ------------------------------------------------------------------- */
+
+    /**
+     * The model's total probability mass on trees containing at least one novel
+     * clade, {@code P(novel) = 1 - M(root)}, where
+     * {@code M(c) = disc(c) * sum_{observed (L,R)} ccp(L,R) * M(L) * M(R)} is the
+     * mass on subtrees of {@code c} that stay entirely within the observed clade
+     * set, and {@code disc(c) = 1 - mu} for clades that reserve escape mass (the
+     * tail correction is negligible for this aggregate). Compare against the
+     * empirical fraction of held-out trees that {@link #containsNovelClade}.
+     *
+     * @return model probability that a tree contains a novel clade
+     */
+    public double getNovelCladeProbability() {
+        return getNovelCladeProbability(mu);
+    }
+
+    /**
+     * Closed-form P(tree contains a novel clade) at an arbitrary escape probability {@code atMu},
+     * reusing this model's (mu-independent) alpha-smoothed backbone CCPs and reservability. This is the
+     * P(novel) analogue of {@link #getLogProbabilityOfTree(Tree, double)}: it lets a sweep evaluate many
+     * mu on one trained backbone without rebuilding. For {@code atMu == mu} it equals the no-arg form.
+     */
+    public double getNovelCladeProbability(double atMu) {
+        return 1.0 - massNoNovelClade(getRootClade(), new HashMap<>(), atMu);
+    }
+
+    private double massNoNovelClade(Clade c, Map<Clade, Double> memo, double atMu) {
+        if (c.isLeaf()) {
+            return 1.0;
+        }
+        Double cached = memo.get(c);
+        if (cached != null) {
+            return cached;
+        }
+        double sum = 0.0;
+        for (CladePartition p : c.getPartitions()) {
+            Clade[] ch = p.getChildClades();
+            sum += p.getCCP() * massNoNovelClade(ch[0], memo, atMu) * massNoNovelClade(ch[1], memo, atMu);
+        }
+        double m = (cheapReservable(c) ? (1.0 - atMu) : 1.0) * sum;
+        memo.put(c, m);
+        return m;
+    }
+
+    /**
+     * Cheap reservability test (early-exit over the reserve-depth orders), used
+     * for the aggregate {@link #getNovelCladeProbability} where the exact tail is
+     * not needed.
+     */
+    private boolean cheapReservable(Clade c) {
+        if (c.size() < 3) {
+            return false;
+        }
+        List<Clade> subs = observedSubclades(c);
+        enumOps.get()[0] = 0;
+        try {
+            for (int j = 3; j <= reserveBoundary && j <= c.size(); j++) {
+                if (countNj(c, subs, j, true) > 0) {
+                    return true;
+                }
+            }
+        } catch (BudgetExceeded e) {
+            // boundary 3 (O(m^2)) always completes
+        }
+        return false;
+    }
+
+    /** Whether the given tree contains a clade that is not in the (expanded) CCD. */
+    public boolean containsNovelClade(Tree tree) {
+        Map<Node, BitSet> bits = new HashMap<>();
+        computeBits(tree.getRoot(), bits);
+        for (Map.Entry<Node, BitSet> e : bits.entrySet()) {
+            if (!e.getKey().isLeaf() && getClade(e.getValue()) == null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private BitSet computeBits(Node v, Map<Node, BitSet> bits) {
+        BitSet b = BitSet.newBitSet(leafArraySize);
+        if (v.isLeaf()) {
+            b.set(v.getNr());
+        } else {
+            b.or(computeBits(v.getChildren().get(0), bits));
+            b.or(computeBits(v.getChildren().get(1), bits));
+        }
+        bits.put(v, b);
+        return b;
+    }
+
+    /**
+     * Scores the subtree at {@code v} at escape probability {@code scoreMu}.
+     * {@code useStoredReg} controls the source of the per-clade reserve: when {@code true}
+     * (the {@code scoreMu == mu} path) it uses the cached {@code eps}/{@code tail} solved at
+     * construction; when {@code false} it re-solves {@code eps} from the cached {@code N_j} at
+     * {@code scoreMu} with tail = 0 (the held-out / mu-search path).
+     */
+    private void scoreFresh(Node v, Map<Node, BitSet> bits, double[] logp,
+                            double scoreMu, boolean useStoredReg) {
+        if (v.isLeaf() || logp[0] == Double.NEGATIVE_INFINITY) {
+            return;
+        }
+        Node c1 = v.getChildren().get(0);
+        Node c2 = v.getChildren().get(1);
+        BitSet vb = bits.get(v);
+
+        if (isRed(vb, bits.get(c1), bits.get(c2))) {
+            Clade c = getClade(vb);
+            CladeReg reg = computeReg(c);
+            if (reg.reservable()) {
+                // tail = 0 for NONE / the mu-search path -> plain (1 - mu); otherwise (1 - mu - tail)
+                double tail = useStoredReg ? reg.tail() : 0.0;
+                logp[0] += Math.log(1.0 - scoreMu - tail);
+            }
+            logp[0] += rawLogCCP(c, bits.get(c1), bits.get(c2));
+            scoreFresh(c1, bits, logp, scoreMu, useStoredReg);
+            scoreFresh(c2, bits, logp, scoreMu, useStoredReg);
+        } else {
+            // v is the top of a maximal blue region. No truncation: every region
+            // is scored, so any tree gets nonzero probability (full support).
+            List<Node> boundary = new ArrayList<>();
+            collectRegion(v, bits, boundary);
+            int m = boundary.size();
+            Clade c = getClade(vb); // region top is always an observed clade
+            BitSet[] parts = new BitSet[m];
+            for (int i = 0; i < m; i++) {
+                parts[i] = bits.get(boundary.get(i));
+            }
+            // SHARED shares a boundary's eps^(m-2) over its pathcount resolutions (-> -log pathcount);
+            // FLAT prices each distinct resolution eps^(m-2) directly (no pathcount normaliser).
+            double logPath = (novelMode == NovelMode.FLAT)
+                    ? 0.0 : Math.log(countAllNovelResolutions(vb, parts));
+            double logEps = useStoredReg ? computeReg(c).logEps() : logEpsAtMu(c, scoreMu);
+            if (logEps == Double.NEGATIVE_INFINITY) {
+                // C reserves nothing computable: give this region fallback mass
+                // mu (SHARED: shared over its pathcount resolutions)
+                logp[0] += Math.log(scoreMu) - logPath;
+            } else {
+                // m - 2 = number of novel clades in this region: one log eps each
+                logp[0] += (m - EXP_REDUCTION) * logEps - logPath;
+            }
+            for (Node b : boundary) {
+                scoreFresh(b, bits, logp, scoreMu, useStoredReg);
+            }
+        }
+    }
+
+    /**
+     * Re-solves {@code log eps(C)} from the cached ({@code mu}-independent) {@code N_j} counts at
+     * an arbitrary {@code scoreMu}; {@code NEGATIVE_INFINITY} if {@code C} reserves nothing.
+     */
+    private double logEpsAtMu(Clade c, double scoreMu) {
+        CladeReg reg = computeReg(c);
+        if (!reg.reservable()) {
+            return Double.NEGATIVE_INFINITY;
+        }
+        return solveLogEps(reg.nCounts(), reg.lastBoundary(), scoreMu);
+    }
+
+    private void collectRegion(Node v, Map<Node, BitSet> bits, List<Node> boundary) {
+        for (Node child : v.getChildren()) {
+            if (child.isLeaf()) {
+                boundary.add(child);
+            } else if (isRed(bits.get(child), bits.get(child.getChildren().get(0)),
+                    bits.get(child.getChildren().get(1)))) {
+                boundary.add(child);
+            } else {
+                collectRegion(child, bits, boundary);
+            }
+        }
+    }
+
+    /* ----------------------------------------------------------------------
+     * Tree sampling (full support)
+     *
+     * The inherited AbstractCCD sampler only ever picks an observed clade partition, so it
+     * draws from the truncated red-only distribution and can never produce a novel clade. We
+     * override the recursion so that at each reservable observed clade we either take an
+     * observed (red) split with probability 1 - mu, or escape (probability mu, or mu + tail in
+     * FULL_SUPPORT) into a blue region: a binary resolution of the clade through novel
+     * intermediate clades down to a boundary of observed subclades. The escape draw reproduces
+     * the score's blue-region weight exactly:
+     *   P(region) = escapeMass * (N_j eps^j / escapeMass) * (1/N_j) * (1/pathcount)
+     *             = eps^(m-2) / pathcount.
+     * Boundary parts are resolved red (an observed split), which makes regions maximal and the
+     * decomposition unique, matching scoreFresh's collectRegion. The PROB/LOG_PROB metadata is
+     * stamped with the same factors scoreFresh charges, so the materialised tree's stamped
+     * (log-)probability equals getLogProbabilityOfTree of that tree.
+     * ------------------------------------------------------------------- */
+
+    /**
+     * Selects how faithfully {@link #sampleTree()} reproduces the full-support score; see
+     * {@link SamplingFidelity}. Default {@link SamplingFidelity#SELF_CONSISTENT}.
+     */
+    public void setSamplingFidelity(SamplingFidelity fidelity) {
+        this.samplingFidelity = fidelity;
+    }
+
+    public SamplingFidelity getSamplingFidelity() {
+        return samplingFidelity;
+    }
+
+    @Override
+    protected Node getVertexBasedOnStrategy(Clade clade, SamplingStrategy samplingStrategy,
+                                            HeightSettingStrategy heightStrategy) {
+        // Escape sampling is meaningful only for random Sampling; point estimates (MAP,
+        // MaxSumCladeCredibility) and leaves keep the inherited observed-only behaviour.
+        if (samplingStrategy != SamplingStrategy.Sampling || clade.isLeaf()) {
+            return super.getVertexBasedOnStrategy(clade, samplingStrategy, heightStrategy);
+        }
+
+        CladeReg reg = computeReg(clade);
+        if (reg.reservable()) {
+            double eps = Math.exp(reg.logEps());
+            double[] orderWeight = escapeOrderWeights(clade, reg, eps);
+            double escapeMass = 0.0;
+            for (double w : orderWeight) {
+                escapeMass += w;
+            }
+            if (escapeMass > 0 && random.nextDouble() < escapeMass) {
+                Node region = sampleBlueRegion(clade, reg, orderWeight, escapeMass, heightStrategy);
+                if (region != null) {
+                    return region;
+                }
+                // region sampling hit the op-budget; fall through to an observed split
+            }
+        }
+        return resolveRedRoot(clade, samplingStrategy, heightStrategy);
+    }
+
+    /**
+     * Resolves {@code clade} with an observed (red) split and recurses into its children
+     * through the overriding sampler (so descendant clades may still escape). Stamps the same
+     * {@code (1 - mu - tail) * theta} factor scoreFresh charges at a red node. Leaves delegate
+     * to the inherited leaf construction.
+     */
+    private Node resolveRedRoot(Clade clade, SamplingStrategy samplingStrategy,
+                                HeightSettingStrategy heightStrategy) {
+        if (clade.isLeaf()) {
+            return super.getVertexBasedOnStrategy(clade, samplingStrategy, heightStrategy);
+        }
+        CladePartition partition = getPartitionBasedOnStrategy(clade, samplingStrategy);
+        if (partition == null) {
+            throw new AssertionError("Unsuccessful to find clade partition of clade: "
+                    + clade.getCladeInBits());
+        }
+        Node firstChild = getVertexBasedOnStrategy(partition.getChildClades()[0],
+                samplingStrategy, heightStrategy);
+        Node secondChild = getVertexBasedOnStrategy(partition.getChildClades()[1],
+                samplingStrategy, heightStrategy);
+        Node vertex = buildInternalVertex(clade, partition, firstChild, secondChild, heightStrategy);
+        CladeReg reg = computeReg(clade);
+        if (reg.reservable()) {
+            applyLogFactor(vertex, Math.log(1.0 - mu - reg.tail()));
+        }
+        return vertex;
+    }
+
+    /**
+     * Escape weight per boundary size: {@code w[m] = N_m * eps^(m-2)}. SELF_CONSISTENT uses the
+     * computed orders (whose sum is mu); FULL_SUPPORT additionally Knuth-estimates the leading
+     * tail orders ({@code k+1, k+2}).
+     */
+    private double[] escapeOrderWeights(Clade c, CladeReg reg, double eps) {
+        int maxBoundary = reg.lastBoundary();
+        int[] n = reg.nCounts();
+        int hi = maxBoundary;
+        if (samplingFidelity == SamplingFidelity.FULL_SUPPORT) {
+            hi = Math.min(c.size(), reserveBoundary + 2);
+        }
+        double[] w = new double[Math.max(maxBoundary, hi) + 1];
+        for (int m = 3; m <= maxBoundary; m++) {
+            if (n[m] > 0) {
+                w[m] = n[m] * Math.pow(eps, m - EXP_REDUCTION);
+            }
+        }
+        if (samplingFidelity == SamplingFidelity.FULL_SUPPORT && hi > maxBoundary) {
+            List<Clade> subs = observedSubclades(c);
+            for (int m = maxBoundary + 1; m <= hi; m++) {
+                double nm = estimateNj(c, subs, m, TAIL_SAMPLES);
+                if (nm > 0) {
+                    w[m] = nm * Math.pow(eps, m - EXP_REDUCTION);
+                }
+            }
+        }
+        return w;
+    }
+
+    /**
+     * Samples a maximal blue region rooted at observed clade {@code c}: draws a boundary size,
+     * a uniform valid boundary, a uniform all-novel resolution shape, resolves the boundary parts
+     * red, and stamps the region factor {@code eps^(m-2)/pathcount}. Returns {@code null} if the
+     * boundary enumeration exceeds the op-budget (the caller then takes an observed split).
+     */
+    private Node sampleBlueRegion(Clade c, CladeReg reg, double[] orderWeight, double escapeMass,
+                                  HeightSettingStrategy heightStrategy) {
+        double target = random.nextDouble() * escapeMass;
+        double acc = 0.0;
+        int m = -1;
+        for (int mm = 3; mm < orderWeight.length; mm++) {
+            if (orderWeight[mm] <= 0) {
+                continue;
+            }
+            acc += orderWeight[mm];
+            if (target < acc) {
+                m = mm;
+                break;
+            }
+        }
+        if (m < 0) { // numerical guard: fall back to the largest available order
+            for (int mm = orderWeight.length - 1; mm >= 3; mm--) {
+                if (orderWeight[mm] > 0) {
+                    m = mm;
+                    break;
+                }
+            }
+        }
+        if (m < 0) {
+            return null;
+        }
+
+        List<Clade> subs = observedSubclades(c);
+        BitSet[] parts;
+        try {
+            parts = sampleBoundary(c, subs, m);
+        } catch (BudgetExceeded e) {
+            return null;
+        }
+        if (parts == null) {
+            return null;
+        }
+
+        Resolution res = sampleResolution(c.getCladeInBits(), parts);
+
+        // Resolve every boundary part with an observed split (red) so the region is maximal.
+        Node[] boundaryNodes = new Node[m];
+        for (int i = 0; i < m; i++) {
+            Clade part = getClade(parts[i]);
+            boundaryNodes[i] = resolveRedRoot(part, SamplingStrategy.Sampling, heightStrategy);
+        }
+
+        double topHeight = regionTopHeight(c, heightStrategy);
+        Node region = assembleRegion(res.shape(), boundaryNodes, c, topHeight, heightStrategy);
+        // One factor of eps per novel clade (m - 2 of them). SHARED spreads it over the pathcount
+        // resolutions (-log pathcount); FLAT prices the resolution directly (boundary already drawn
+        // proportional to pathcount above), matching the FLAT scorer.
+        double regionFactor = (m - EXP_REDUCTION) * reg.logEps();
+        if (novelMode == NovelMode.SHARED) {
+            regionFactor -= Math.log(res.pathcount());
+        }
+        applyLogFactor(region, regionFactor);
+        return region;
+    }
+
+    /**
+     * Uniformly samples one valid boundary of {@code c} into {@code m} observed subclades
+     * (admitting an all-novel resolution) by reservoir sampling over the same canonical
+     * enumeration {@link #countNj} counts. Returns the chosen parts, or {@code null} if none.
+     */
+    private BitSet[] sampleBoundary(Clade c, List<Clade> subs, int m) {
+        boundarySeen = 0;
+        boundaryWeightSeen = 0.0;
+        boundaryPick = null;
+        enumOps.get()[0] = 0;
+        sampleBoundaryWalk(c.getCladeInBits(), subs, m, 0,
+                BitSet.newBitSet(leafArraySize), new ArrayList<>(m));
+        return boundaryPick;
+    }
+
+    private void sampleBoundaryWalk(BitSet cBits, List<Clade> subs, int m, int startIdx,
+                                    BitSet used, List<BitSet> chosen) {
+        if (++enumOps.get()[0] > opsBudget) {
+            throw BUDGET_EXCEEDED;
+        }
+        if (chosen.size() == m - 1) {
+            BitSet last = (BitSet) cBits.clone();
+            last.andNot(used);
+            if (last.cardinality() == 0 || getClade(last) == null) {
+                return;
+            }
+            if (compareBitSets(chosen.get(chosen.size() - 1), last) >= 0) {
+                return;
+            }
+            BitSet[] parts = new BitSet[m];
+            for (int i = 0; i < m - 1; i++) {
+                parts[i] = chosen.get(i);
+            }
+            parts[m - 1] = last;
+            int pc = countAllNovelResolutions(cBits, parts);
+            if (pc <= 0) {
+                return;
+            }
+            if (novelMode == NovelMode.FLAT) {
+                // FLAT samples a boundary in proportion to its pathcount (so that, with the
+                // uniform resolution pick below, every distinct novel tree is equiprobable).
+                boundaryWeightSeen += pc;
+                if (random.nextDouble() * boundaryWeightSeen < pc) { // weighted reservoir
+                    boundaryPick = parts;
+                }
+            } else {
+                boundarySeen++;
+                if (random.nextInt(boundarySeen) == 0) { // uniform reservoir: keep with prob 1/seen
+                    boundaryPick = parts;
+                }
+            }
+            return;
+        }
+        for (int i = startIdx; i < subs.size(); i++) {
+            BitSet pb = subs.get(i).getCladeInBits();
+            if (pb.intersects(used)) {
+                continue;
+            }
+            chosen.add(pb);
+            BitSet newUsed = (BitSet) used.clone();
+            newUsed.or(pb);
+            sampleBoundaryWalk(cBits, subs, m, i + 1, newUsed, chosen);
+            chosen.remove(chosen.size() - 1);
+        }
+    }
+
+    /**
+     * A sampled all-novel resolution of a clade into its boundary parts, with the total number
+     * of such resolutions (the pathcount) that normalises the region.
+     */
+    private record Resolution(Shape shape, int pathcount) {
+    }
+
+    /**
+     * Node of a sampled resolution shape: a boundary part (leaf, {@code partIndex >= 0}) or a
+     * novel internal split with two children.
+     */
+    private static final class Shape {
+        final BitSet union;
+        final int partIndex;
+        final Shape left;
+        final Shape right;
+
+        Shape(BitSet union, int partIndex) {
+            this.union = union;
+            this.partIndex = partIndex;
+            this.left = null;
+            this.right = null;
+        }
+
+        Shape(BitSet union, Shape left, Shape right) {
+            this.union = union;
+            this.partIndex = -1;
+            this.left = left;
+            this.right = right;
+        }
+
+        boolean isLeaf() {
+            return partIndex >= 0;
+        }
+    }
+
+    /**
+     * Uniformly samples one all-novel binary resolution of {@code cBits} into {@code parts} by
+     * top-down sampling from the same subset DP {@link #countAllNovelResolutions} builds (at each
+     * mask a split is chosen with probability proportional to {@code f[s1]*f[s2]}).
+     */
+    private Resolution sampleResolution(BitSet cBits, BitSet[] parts) {
+        int k = parts.length;
+        if (k == 1) {
+            return new Resolution(new Shape(parts[0], 0), 1);
+        }
+        int full = (1 << k) - 1;
+        BitSet[] unionOf = new BitSet[1 << k];
+        unionOf[0] = BitSet.newBitSet(leafArraySize);
+        for (int mask = 1; mask <= full; mask++) {
+            int low = Integer.numberOfTrailingZeros(mask);
+            BitSet u = (BitSet) unionOf[mask & (mask - 1)].clone();
+            u.or(parts[low]);
+            unionOf[mask] = u;
+        }
+        int[] f = new int[1 << k];
+        for (int mask = 1; mask <= full; mask++) {
+            if (Integer.bitCount(mask) == 1) {
+                f[mask] = 1;
+                continue;
+            }
+            int low = mask & (-mask);
+            int rest = mask ^ low;
+            int count = 0;
+            for (int sub = rest; ; sub = (sub - 1) & rest) {
+                int s1 = sub | low;
+                int s2 = mask ^ s1;
+                if (s2 != 0 && !isSplitObserved(unionOf[mask], unionOf[s1], unionOf[s2])) {
+                    count += f[s1] * f[s2];
+                }
+                if (sub == 0) {
+                    break;
+                }
+            }
+            f[mask] = count;
+        }
+        Shape shape = sampleShape(full, parts, unionOf, f);
+        return new Resolution(shape, f[full]);
+    }
+
+    private Shape sampleShape(int mask, BitSet[] parts, BitSet[] unionOf, int[] f) {
+        if (Integer.bitCount(mask) == 1) {
+            int idx = Integer.numberOfTrailingZeros(mask);
+            return new Shape(parts[idx], idx);
+        }
+        int low = mask & (-mask);
+        int rest = mask ^ low;
+        int targetCount = random.nextInt(f[mask]); // f[mask] > 0 at every visited mask
+        int acc = 0;
+        int chosenS1 = -1;
+        int chosenS2 = -1;
+        for (int sub = rest; ; sub = (sub - 1) & rest) {
+            int s1 = sub | low;
+            int s2 = mask ^ s1;
+            if (s2 != 0 && !isSplitObserved(unionOf[mask], unionOf[s1], unionOf[s2])) {
+                acc += f[s1] * f[s2];
+                if (targetCount < acc) {
+                    chosenS1 = s1;
+                    chosenS2 = s2;
+                    break;
+                }
+            }
+            if (sub == 0) {
+                break;
+            }
+        }
+        Shape left = sampleShape(chosenS1, parts, unionOf, f);
+        Shape right = sampleShape(chosenS2, parts, unionOf, f);
+        return new Shape((BitSet) unionOf[mask].clone(), left, right);
+    }
+
+    /**
+     * Materialises a sampled resolution shape into nodes: boundary parts reuse their already
+     * resolved (red) nodes, novel internal nodes get fresh nodes with identity probability factors
+     * (the region factor is applied once at the top by the caller) and interpolated heights.
+     */
+    private Node assembleRegion(Shape shape, Node[] boundaryNodes, Clade c, double topHeight,
+                                HeightSettingStrategy heightStrategy) {
+        if (shape.isLeaf()) {
+            return boundaryNodes[shape.partIndex];
+        }
+        Node left = assembleRegion(shape.left, boundaryNodes, c, topHeight, heightStrategy);
+        Node right = assembleRegion(shape.right, boundaryNodes, c, topHeight, heightStrategy);
+
+        Node vertex = new Node();
+        vertex.setNr(nextRunningInnerIndex());
+        vertex.addChild(left);
+        vertex.addChild(right);
+
+        boolean isTop = shape.union.equals(c.getCladeInBits());
+        Clade obs = getClade(shape.union); // observed at the top (= c) and at any observed interior
+        double support = (obs != null) ? obs.getProbability() : 0.0;
+        vertex.setMetaData(CLADE_SUPPORT_KEY, support);
+        String posteriorSupport = CLADE_SUPPORT_KEY + "=" + support;
+        vertex.metaDataString = (vertex.metaDataString != null)
+                ? vertex.metaDataString + "," + posteriorSupport : posteriorSupport;
+
+        // identity factors: the per-region eps^(m-2)/pathcount is stamped once at the region top.
+        vertex.setMetaData(PROB_SUBTREE_KEY,
+                (Double) left.getMetaData(PROB_SUBTREE_KEY) * (Double) right.getMetaData(PROB_SUBTREE_KEY));
+        vertex.setMetaData(LOG_PROB_SUBTREE_KEY,
+                (Double) left.getMetaData(LOG_PROB_SUBTREE_KEY) + (Double) right.getMetaData(LOG_PROB_SUBTREE_KEY));
+
+        setNovelHeight(vertex, left, right, isTop, topHeight, heightStrategy);
+        return vertex;
+    }
+
+    /**
+     * Region-top height under the given strategy ({@code NaN} for One/None, which the novel-height
+     * scheme handles without a fixed top).
+     */
+    private double regionTopHeight(Clade c, HeightSettingStrategy heightStrategy) {
+        if (heightStrategy == HeightSettingStrategy.MeanOccurredHeights) {
+            return c.getMeanOccurredHeight();
+        }
+        if (heightStrategy == HeightSettingStrategy.CommonAncestorHeights) {
+            return c.getCommonAncestorHeight();
+        }
+        return Double.NaN;
+    }
+
+    /**
+     * Sets a height for a novel (or region-top) internal node that keeps branch lengths positive:
+     * One uses {@code max(child) + 1}; Mean/CommonAncestor put the top at its clade height and each
+     * interior node at the midpoint between its children and the top, falling back to
+     * {@code max(child) + eps} if the top is not strictly above the children; None leaves it unset.
+     */
+    private void setNovelHeight(Node vertex, Node left, Node right, boolean isTop,
+                                double topHeight, HeightSettingStrategy heightStrategy) {
+        if (heightStrategy == null || heightStrategy == HeightSettingStrategy.None) {
+            return;
+        }
+        double maxChild = Math.max(left.getHeight(), right.getHeight());
+        double height;
+        if (heightStrategy == HeightSettingStrategy.One) {
+            height = maxChild + 1.0;
+        } else if (isTop) {
+            height = (topHeight > maxChild) ? topHeight : maxChild + NOVEL_HEIGHT_EPS;
+        } else {
+            height = (topHeight > maxChild) ? 0.5 * (maxChild + topHeight) : maxChild + NOVEL_HEIGHT_EPS;
+        }
+        vertex.setHeight(height);
+    }
+
+    private static void applyLogFactor(Node vertex, double logFactor) {
+        vertex.setMetaData(LOG_PROB_SUBTREE_KEY,
+                (Double) vertex.getMetaData(LOG_PROB_SUBTREE_KEY) + logFactor);
+        vertex.setMetaData(PROB_SUBTREE_KEY,
+                (Double) vertex.getMetaData(PROB_SUBTREE_KEY) * Math.exp(logFactor));
+    }
+
+    /* ----------------------------------------------------------------------
+     * Observed-split / observed-clade queries
+     * ------------------------------------------------------------------- */
+
+    private boolean isSplitObserved(BitSet parentBits, BitSet c1Bits, BitSet c2Bits) {
+        Clade parent = getClade(parentBits);
+        if (parent == null) {
+            return false;
+        }
+        Clade a = getClade(c1Bits);
+        if (a == null) {
+            return false;
+        }
+        Clade b = getClade(c2Bits);
+        if (b == null) {
+            return false;
+        }
+        return parent.getCladePartition(a, b) != null;
+    }
+
+    private boolean isRed(BitSet parentBits, BitSet c1Bits, BitSet c2Bits) {
+        return isSplitObserved(parentBits, c1Bits, c2Bits);
+    }
+
+    private double rawLogCCP(Clade parent, BitSet c1Bits, BitSet c2Bits) {
+        Clade a = getClade(c1Bits);
+        Clade b = getClade(c2Bits);
+        CladePartition p = parent.getCladePartition(a, b);
+        return p.getLogCCP();
+    }
+
+    /* ----------------------------------------------------------------------
+     * pathcount: number of all-novel resolutions of C into the given parts,
+     * via a subset DP over the parts (handles any boundary size).
+     * ------------------------------------------------------------------- */
+
+    private int countAllNovelResolutions(BitSet cBits, BitSet[] parts) {
+        int k = parts.length;
+        if (k == 1) {
+            return 1;
+        }
+        int full = (1 << k) - 1;
+        BitSet[] unionOf = new BitSet[1 << k];
+        unionOf[0] = BitSet.newBitSet(leafArraySize);
+        for (int mask = 1; mask <= full; mask++) {
+            int low = Integer.numberOfTrailingZeros(mask);
+            BitSet u = (BitSet) unionOf[mask & (mask - 1)].clone();
+            u.or(parts[low]);
+            unionOf[mask] = u;
+        }
+        int[] f = new int[1 << k];
+        for (int mask = 1; mask <= full; mask++) {
+            if (Integer.bitCount(mask) == 1) {
+                f[mask] = 1;
+                continue;
+            }
+            int low = mask & (-mask); // lowest set bit, fixed in S1 to avoid double counting
+            int rest = mask ^ low;
+            int count = 0;
+            // iterate non-empty proper submasks S1 of mask that contain `low`
+            for (int sub = rest; ; sub = (sub - 1) & rest) {
+                int s1 = sub | low;
+                int s2 = mask ^ s1;
+                if (s2 != 0 && !isSplitObserved(unionOf[mask], unionOf[s1], unionOf[s2])) {
+                    count += f[s1] * f[s2];
+                }
+                if (sub == 0) {
+                    break;
+                }
+            }
+            f[mask] = count;
+        }
+        return f[full];
+    }
+
+    /**
+     * Eagerly compute and cache the per-clade reserve eps for every clade in this CCD. The reserve solve
+     * runs the op-capped N_j enumeration once per clade ({@link #computeReg}); doing it up front means
+     * subsequent {@code sampleTree}/{@code getLogProbabilityOfTree} calls hit {@code regCache} instead of
+     * paying that enumeration lazily — and unevenly — during the first samples. Idempotent (cache hits
+     * after the first call). Useful before a large sampling loop (e.g. variational ELBO estimation).
+     */
+    public void precomputeReserves() {
+        // Clades are independent: each computeReg only reads immutable clade structure + writes its own
+        // entry in the (concurrent) regCache, and the op-budget counter is thread-local. With tailMode
+        // BOUND/NONE there is no random tail estimation, so this is deterministic and thread-safe.
+        cladeMapping.values().parallelStream().forEach(this::computeReg);
+    }
+
+    /** The per-clade enumeration op budget: an explicit {@code -Dkreg.enumOps} override (accepts
+     *  {@code 1e7} or {@code 10000000}), else {@link #OPS_BUDGET_FACTOR} times the largest clade's N_1
+     *  cost (root subclade count squared), floored at {@link #MIN_OPS_BUDGET}. Scales with dataset size
+     *  so N_1 always completes while deep orders stay capped. */
+    private long computeOpsBudget() {
+        String override = System.getProperty("kreg.enumOps");
+        if (override != null && !override.isBlank()) {
+            return (long) Double.parseDouble(override.trim());
+        }
+        long m = observedSubclades(getRootClade()).size();   // largest clade's observed-subclade count
+        return Math.max(MIN_OPS_BUDGET, OPS_BUDGET_FACTOR * m * m);
+    }
+
+    /** The per-clade enumeration op budget in effect (see {@link #computeOpsBudget}). */
+    public long getOpsBudget() {
+        return opsBudget;
+    }
+
+    /* ----------------------------------------------------------------------
+     * Per-clade reservation: N_j and eps
+     * ------------------------------------------------------------------- */
+
+    /* Per-clade reserve: solve eps from R(C) = sum_{j>=1} N_{j+2} eps^j = mu using
+     * orders up to the reserve depth (boundaries 3..reserveBoundary; climbing to the
+     * first nonzero order if those are all zero, so eps stays positive), and bound
+     * the omitted tail (orders > k) geometrically from the two computed orders:
+     *   rho = (N_2/N_1) eps,  tail <= N_2 eps^2 * rho/(1-rho)
+     * (rigorous if the N_j are log-concave; clamped to [0, mu]). Computed once per
+     * clade and cached. */
+    private CladeReg computeReg(Clade c) {
+        CladeReg cached = regCache.get(c);
+        if (cached != null) {
+            return cached;
+        }
+        CladeReg reg;
+        if (c.size() < 3) {
+            reg = new CladeReg(false, Double.NEGATIVE_INFINITY, 0.0, null, 0);
+            regCache.put(c, reg);
+            return reg;
+        }
+        List<Clade> subs = observedSubclades(c);
+        int[] n = new int[c.size() + 1];
+        int last = 2;
+        boolean anyNonzero = false;
+        enumOps.get()[0] = 0;
+        for (int j = 3; j <= c.size(); j++) {
+            if (j > reserveBoundary && anyNonzero) {
+                break; // reached reserve depth and have a usable (positive) reserve
+            }
+            try {
+                n[j] = countNj(c, subs, j, false); // accumulates enumOps across j
+            } catch (BudgetExceeded e) {
+                break;
+            }
+            last = j;
+            if (n[j] > 0) {
+                anyNonzero = true;
+            }
+        }
+        double logEps = anyNonzero ? solveLogEps(n, last, mu) : Double.NEGATIVE_INFINITY;
+
+        double tail = 0.0;
+        int n1 = n[3];
+        int n2 = (n.length > 4) ? n[4] : 0;
+        if (tailMode != TailMode.NONE && logEps != Double.NEGATIVE_INFINITY && n1 > 0 && n2 > 0) {
+            double eps = Math.exp(logEps);
+            // geometric upper bound from the two computed orders (rigorous if log-concave)
+            double rho = ((double) n2 / n1) * eps;
+            double tailUB = (rho > 0 && rho < 1) ? n2 * eps * eps * rho / (1 - rho) : mu;
+            tailUB = Math.min(tailUB, mu);
+
+            if (tailMode == TailMode.BOUND || tailUB < TAIL_SAMPLE_THRESHOLD) {
+                // BOUND mode, or a negligible bound: use the (cheap) bound directly
+                tail = tailUB;
+            } else {
+                // SAMPLED mode with a non-negligible bound: Knuth-estimate the actual
+                // tail (orders > reserve depth), summing the two leading orders
+                tail = 0.0;
+                for (int m = reserveBoundary + 1; m <= reserveBoundary + 2 && m <= c.size(); m++) {
+                    double nm = estimateNj(c, subs, m, TAIL_SAMPLES);
+                    tail += nm * Math.pow(eps, m - EXP_REDUCTION);
+                }
+                tail = Math.min(tail, mu);
+            }
+        }
+
+        reg = new CladeReg(anyNonzero, logEps, tail, anyNonzero ? n : null, last);
+        regCache.put(c, reg);
+        return reg;
+    }
+
+    /* Knuth (1975) backtrack-tree estimator of N_m (number of valid boundary-m
+     * partitions): average over random root-to-leaf descents of the product of
+     * branching factors, times the leaf-valid indicator. Each descent is O(m * |subs|);
+     * unbiased. */
+    private double estimateNj(Clade c, List<Clade> subs, int m, int samples) {
+        BitSet cBits = c.getCladeInBits();
+        double sum = 0.0;
+        for (int s = 0; s < samples; s++) {
+            sum += knuthDescent(cBits, subs, m);
+        }
+        return sum / samples;
+    }
+
+    private double knuthDescent(BitSet cBits, List<Clade> subs, int m) {
+        BitSet used = BitSet.newBitSet(leafArraySize);
+        double product = 1.0;
+        int startIdx = 0;
+        BitSet prev = null;
+        BitSet[] chosen = new BitSet[m];
+        for (int level = 0; level < m - 1; level++) {
+            // children = candidates at index >= startIdx disjoint from `used`
+            int d = 0;
+            for (int i = startIdx; i < subs.size(); i++) {
+                if (!subs.get(i).getCladeInBits().intersects(used)) {
+                    d++;
+                }
+            }
+            if (d == 0) {
+                return 0.0; // dead end
+            }
+            product *= d;
+            int target = rng.nextInt(d);
+            int pickIdx = -1, seen = 0;
+            for (int i = startIdx; i < subs.size(); i++) {
+                if (!subs.get(i).getCladeInBits().intersects(used)) {
+                    if (seen == target) {
+                        pickIdx = i;
+                        break;
+                    }
+                    seen++;
+                }
+            }
+            BitSet pb = subs.get(pickIdx).getCladeInBits();
+            chosen[level] = pb;
+            used = (BitSet) used.clone();
+            used.or(pb);
+            prev = pb;
+            startIdx = pickIdx + 1;
+        }
+        BitSet last = (BitSet) cBits.clone();
+        last.andNot(used);
+        if (last.cardinality() == 0 || getClade(last) == null) {
+            return 0.0;
+        }
+        if (compareBitSets(prev, last) >= 0) {
+            return 0.0; // canonical order violated
+        }
+        chosen[m - 1] = last;
+        return countAllNovelResolutions(cBits, chosen) > 0 ? product : 0.0;
+    }
+
+    /* Observed clades strictly contained in C, sorted in canonical (lexicographic) order. */
+    private List<Clade> observedSubclades(Clade c) {
+        List<Clade> subs = new ArrayList<>();
+        int cSize = c.size();
+        for (Clade x : getClades()) {
+            int s = x.size();
+            if (s >= 1 && s < cSize && c.contains(x.getCladeInBitsTaxaOnly())) {
+                subs.add(x);
+            }
+        }
+        subs.sort((a, b) -> compareBitSets(a.getCladeInBits(), b.getCladeInBits()));
+        return subs;
+    }
+
+    /* Count m-part boundaries of C into observed subclades admitting an all-novel
+     * resolution. earlyExit returns 1 as soon as one is found. */
+    private int countNj(Clade c, List<Clade> subs, int m, boolean earlyExit) {
+        BitSet cBits = c.getCladeInBits();
+        BitSet used = BitSet.newBitSet(leafArraySize);
+        List<BitSet> chosen = new ArrayList<>(m);
+        return enumerate(cBits, subs, m, 0, used, chosen, earlyExit);
+    }
+
+    /* Recursive canonical enumeration: pick (m-1) parts at strictly increasing
+     * indices (= increasing canonical order), then derive the last part as the
+     * complement and require it to be the canonical-largest. */
+    private int enumerate(BitSet cBits, List<Clade> subs, int m, int startIdx,
+                          BitSet used, List<BitSet> chosen, boolean earlyExit) {
+        if (++enumOps.get()[0] > opsBudget) {
+            throw BUDGET_EXCEEDED;
+        }
+        if (chosen.size() == m - 1) {
+            BitSet last = (BitSet) cBits.clone();
+            last.andNot(used);
+            if (last.cardinality() == 0 || getClade(last) == null) {
+                return 0;
+            }
+            BitSet prev = chosen.get(chosen.size() - 1);
+            // canonical: last must be strictly greater than the previous (largest) chosen
+            if (compareBitSets(prev, last) >= 0) {
+                return 0;
+            }
+            BitSet[] parts = new BitSet[m];
+            for (int i = 0; i < m - 1; i++) {
+                parts[i] = chosen.get(i);
+            }
+            parts[m - 1] = last;
+            // SHARED counts admissible boundaries (N_j, an indicator); FLAT counts distinct novel
+            // trees (M_j = sum of pathcount over boundaries) by returning the pathcount itself.
+            int res = countAllNovelResolutions(cBits, parts);
+            return novelMode == NovelMode.FLAT ? res : (res > 0 ? 1 : 0);
+        }
+        int count = 0;
+        for (int i = startIdx; i < subs.size(); i++) {
+            BitSet pb = subs.get(i).getCladeInBits();
+            if (pb.intersects(used)) {
+                continue;
+            }
+            chosen.add(pb);
+            BitSet newUsed = (BitSet) used.clone();
+            newUsed.or(pb);
+            count += enumerate(cBits, subs, m, i + 1, newUsed, chosen, earlyExit);
+            chosen.remove(chosen.size() - 1);
+            if (earlyExit && count > 0) {
+                return count;
+            }
+        }
+        return count;
+    }
+
+    /* Monotone bisection solve of sum_{m>=3} n[m] eps^(m-2) = mu on eps >= 0
+     * (eps^(m-2) = eps^(#novel clades)). */
+    private static double solveLogEps(int[] n, int maxDeg, double mu) {
+        boolean any = false;
+        for (int j = 3; j <= maxDeg; j++) {
+            if (n[j] > 0) {
+                any = true;
+                break;
+            }
+        }
+        if (!any) {
+            return Double.NEGATIVE_INFINITY; // not reservable; eps unused
+        }
+        double lo = 0.0;
+        double hi = 1.0;
+        while (evalPoly(n, maxDeg, hi) < mu) {
+            hi *= 2.0;
+        }
+        for (int it = 0; it < 100; it++) {
+            double mid = 0.5 * (lo + hi);
+            if (evalPoly(n, maxDeg, mid) < mu) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        return Math.log(0.5 * (lo + hi));
+    }
+
+    /* Consistent total order on clade bitsets: compare sorted set-bit indices
+     * lexicographically (a proper prefix sorts before its extension). */
+    private static int compareBitSets(BitSet a, BitSet b) {
+        int ia = a.nextSetBit(0);
+        int ib = b.nextSetBit(0);
+        while (ia >= 0 && ib >= 0) {
+            if (ia != ib) {
+                return Integer.compare(ia, ib);
+            }
+            ia = a.nextSetBit(ia + 1);
+            ib = b.nextSetBit(ib + 1);
+        }
+        // whichever still has set bits is "greater"; -1 (exhausted) sorts first
+        return Integer.compare(ia, ib);
+    }
+
+    /* sum_{m>=3} n[m] * x^(m - 2). */
+    private static double evalPoly(int[] n, int maxDeg, double x) {
+        double s = 0.0;
+        for (int m = 3; m <= maxDeg; m++) {
+            if (n[m] != 0) {
+                s += n[m] * Math.pow(x, m - EXP_REDUCTION);
+            }
+        }
+        return s;
+    }
+}

--- a/src/main/java/ccd/model/MRegCCD.java
+++ b/src/main/java/ccd/model/MRegCCD.java
@@ -1,0 +1,646 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator.TreeSet;
+import ccd.model.bitsets.BitSet;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MRegCCD -- the one-parameter "per-new-split" regularised CCD. It unifies RegCCD's split-expansion
+ * {@code alpha} and KRegCCD's escape {@code mu} into a single per-clade escape rate, giving a
+ * full-support tree distribution with <em>one</em> hyperparameter {@code mu} (and no {@code alpha}).
+ *
+ * <p>The model is a plain {@link CCD1} backbone (raw conditional clade probabilities, no smoothing)
+ * extended with a per-clade escape reserve. The distribution is defined conditionally, clade by clade
+ * (chain rule over the observed-clade DAG; no global partition function):
+ * <ul>
+ *   <li>An <em>observed split</em> {@code C -> {L, R}} (seen in training) is priced
+ *       {@code (1 - mu - tail(C)) * ccp(L|R)} when {@code C} can escape, else just {@code ccp(L|R)}.</li>
+ *   <li>An <em>escape</em> at {@code C} resolves it through novel intermediate clades down to a
+ *       boundary of {@code m} observed subclades (a maximal "blue" region). Such a region has
+ *       {@code m - 1} new splits and is priced {@code eps(C)^(m-1)} -- one factor of {@code eps} per
+ *       new split (so a recombination of two observed subclades, {@code m = 2}, costs one
+ *       {@code eps}). This is the difference from KRegCCD, which makes recombinations representable in
+ *       its {@code alpha}-expanded backbone and charges {@code eps} only per novel <em>clade</em>
+ *       ({@code eps^(m-2)}).</li>
+ * </ul>
+ *
+ * <p>The per-clade escape rate {@code eps(C)} is the root of {@code sum_{m>=2} M_m(C) eps^(m-1) = mu},
+ * where {@code M_m(C)} counts the all-novel resolutions of {@code C} with an {@code m}-part boundary
+ * (the FLAT weighting: each distinct novel resolution counted once). Computing the full sum is
+ * #P-hard, so -- mirroring KRegCCD -- the orders {@code m = 2..reserveDepth} are enumerated exactly
+ * (bounded by an op-budget) and the omitted higher orders are a geometric tail correction added to
+ * {@code mu} (so observed splits are discounted by {@code 1 - mu - tail}, keeping the conditional
+ * properly normalised; truncating without the tail super-normalises). A clade with no escape route
+ * ({@code M_m = 0} for all computed {@code m}) is not reservable and keeps its raw CCP undiscounted.
+ *
+ * <p>Every tree on the taxon set has positive probability (full support), so {@link #containsTree}
+ * is always true and {@link #getLogProbabilityOfTree} is finite for all trees.
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class MRegCCD extends CCD1 {
+
+    /** Default per-clade escape probability (the RSV2 operating point of the conditional model). */
+    public static final double DEFAULT_MU = 0.0159;
+
+    /** Default reserve depth: enumerate boundary sizes {@code m = 2..DEFAULT_RESERVE_DEPTH} exactly. */
+    public static final int DEFAULT_RESERVE_DEPTH = 5;
+
+    /** Per-clade enumeration-op budget (mirrors KRegCCD's; bounds the boundary enumeration). */
+    private static final long OPS_BUDGET = Long.parseLong(System.getProperty("mreg.enumOps", "20000000"));
+
+    private static final class BudgetExceeded extends RuntimeException {
+        BudgetExceeded() {
+            super(null, null, false, false);
+        }
+    }
+
+    private static final BudgetExceeded BUDGET_EXCEEDED = new BudgetExceeded();
+
+    /** Per-clade escape probability (the single hyperparameter). */
+    private final double mu;
+
+    /** Max boundary size enumerated when solving eps; deeper orders are a geometric tail. */
+    private final int reserveDepth;
+
+    /** Whether the {@code (1 - mu - tail)} discount carries the geometric tail correction. */
+    private final boolean useTail;
+
+    /** Observed-clade bitsets (incl. leaves), sorted canonically; built lazily. */
+    private List<BitSet> sortedCladeBits;
+    private final Map<BitSet, List<BitSet>> subCache = new HashMap<>();
+    private final Map<BitSet, int[]> countsCache = new HashMap<>();
+    private long enumOps;
+
+    public MRegCCD(List<Tree> trees, double burnin, double mu) {
+        this(trees, burnin, mu, DEFAULT_RESERVE_DEPTH, true);
+    }
+
+    public MRegCCD(List<Tree> trees, double burnin, double mu, int reserveDepth, boolean useTail) {
+        super(trees, burnin);
+        validate(mu, reserveDepth);
+        this.mu = mu;
+        this.reserveDepth = reserveDepth;
+        this.useTail = useTail;
+    }
+
+    public MRegCCD(TreeSet treeSet, double mu) {
+        this(treeSet, mu, DEFAULT_RESERVE_DEPTH, true);
+    }
+
+    public MRegCCD(TreeSet treeSet, double mu, int reserveDepth, boolean useTail) {
+        super(treeSet);
+        validate(mu, reserveDepth);
+        this.mu = mu;
+        this.reserveDepth = reserveDepth;
+        this.useTail = useTail;
+    }
+
+    /**
+     * Builds an MRegCCD on {@code trees} with {@code mu} selected by maximising cross-validated
+     * held-out log-probability (see {@link ccd.algorithms.regularisation.MRegCCDParameterOptimiser}),
+     * rather than the fixed {@link #DEFAULT_MU}. The honest, no-peeking counterpart of
+     * {@code KRegCCD.withOptimisedParameters}.
+     */
+    public static MRegCCD withOptimisedMu(List<Tree> trees) {
+        double mu = ccd.algorithms.regularisation.MRegCCDParameterOptimiser.optimiseMu(trees).mu();
+        return new MRegCCD(trees, 0.0, mu);
+    }
+
+    private static void validate(double mu, int reserveDepth) {
+        if (mu <= 0 || mu >= 1) {
+            throw new IllegalArgumentException("mu must be in (0, 1), got " + mu);
+        }
+        if (reserveDepth < 2) {
+            throw new IllegalArgumentException("reserveDepth must be >= 2, got " + reserveDepth);
+        }
+    }
+
+    /** The per-clade escape probability this model was built with. */
+    public double getMu() {
+        return mu;
+    }
+
+    public int getReserveDepth() {
+        return reserveDepth;
+    }
+
+    /**
+     * Reserve counts {@code M_m(C)} by boundary size {@code m} (array index {@code m}, valid for
+     * {@code m = 2..min(|C|, reserveDepth)}); {@code M_m} is the number of all-novel resolutions of
+     * {@code C} with an {@code m}-part boundary. The first coefficient {@code M_2} (the {@code eps^1}
+     * term) is exactly the number of CCD0-expanded splits of {@code C} -- recombinations of two
+     * observed subclades whose split was never observed -- since those are the only escapes with no
+     * other novel (blue) clade. Exposed for inspection and cross-checks.
+     */
+    public int[] reserveCounts(BitSet cladeInBits) {
+        return countsFor(cladeInBits).clone();
+    }
+
+    @Override
+    public String toString() {
+        return "MRegCCD [mu = " + mu + ", reserveDepth = " + reserveDepth + ", tail = " + useTail
+                + ", per-new-split, full support]";
+    }
+
+    /* ----------------------------------------------------------------------
+     * Scoring
+     * ------------------------------------------------------------------- */
+
+    @Override
+    public double getLogProbabilityOfTree(Tree tree) {
+        return scoreTree(tree, mu);
+    }
+
+    /**
+     * Full-support log-probability at an arbitrary escape probability {@code scoreMu}, reusing this
+     * model's ({@code mu}-independent) backbone and cached reserve counts. Lets a parameter search /
+     * cross-validation evaluate many {@code mu} on one trained model without rebuilding. For
+     * {@code scoreMu == mu} it equals {@link #getLogProbabilityOfTree(Tree)}.
+     */
+    public double getLogProbabilityOfTree(Tree tree, double scoreMu) {
+        if (scoreMu <= 0 || scoreMu >= 1) {
+            throw new IllegalArgumentException("scoreMu must be in (0, 1), got " + scoreMu);
+        }
+        return scoreTree(tree, scoreMu);
+    }
+
+    @Override
+    public double getProbabilityOfTree(Tree tree) {
+        return Math.exp(getLogProbabilityOfTree(tree));
+    }
+
+    /** Always true: MRegCCD is full support, so every tree on this taxon set has positive probability. */
+    @Override
+    public boolean containsTree(Tree tree) {
+        return true;
+    }
+
+    private double scoreTree(Tree tree, double scoreMu) {
+        Map<Node, BitSet> bits = new HashMap<>();
+        computeBits(tree.getRoot(), bits);
+        double logp = 0.0;
+        for (Node v : tree.getNodesAsArray()) {
+            if (v.isLeaf()) {
+                continue;
+            }
+            BitSet vb = bits.get(v);
+            Clade c = getClade(vb);
+            if (c == null) {
+                continue; // novel clade: scored once at its maximal region's top
+            }
+            BitSet b1 = bits.get(v.getChildren().get(0));
+            BitSet b2 = bits.get(v.getChildren().get(1));
+            if (isSplitObserved(vb, b1, b2)) {
+                if (reservable(vb)) { // discount only clades that can actually escape
+                    double resv = Math.min(scoreMu + (useTail ? tailFor(vb, scoreMu) : 0.0), 1 - 1e-12);
+                    logp += Math.log(1.0 - resv);
+                }
+                logp += rawLogCCP(c, b1, b2); // raw CCD1 CCP
+            } else {
+                // region top: an observed clade resolved through a novel split. m-1 new splits.
+                int m = boundarySize(v, bits);
+                logp += (m - 1) * Math.log(epsFor(vb, scoreMu));
+            }
+        }
+        return logp;
+    }
+
+    /* ----------------------------------------------------------------------
+     * Per-clade reserve  (M_m counts -> eps, tail; mirrors KRegCCD.computeReg)
+     * ------------------------------------------------------------------- */
+
+    /** Whether clade {@code C} (given in bits) reserves any escape mass up to {@code reserveDepth}. */
+    boolean reservable(BitSet C) {
+        for (int v : countsFor(C)) {
+            if (v > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Escape root {@code eps} solving {@code sum_{m>=2} M_m eps^(m-1) = scoreMu} (monotone bisection). */
+    double epsFor(BitSet C, double scoreMu) {
+        int[] n = countsFor(C);
+        if (!reservable(C)) {
+            return scoreMu; // crude fallback (no escape route within reserveDepth); should not be hit
+        }
+        return solveEps(n, scoreMu);
+    }
+
+    /** Omitted-tail escape mass beyond the computed orders: geometric bound from the top two orders. */
+    double tailFor(BitSet C, double scoreMu) {
+        int[] n = countsFor(C);
+        int last = n.length - 1;
+        if (last < 3) {
+            return 0.0;
+        }
+        int nLast = n[last], nPrev = n[last - 1];
+        if (nLast <= 0 || nPrev <= 0) {
+            return 0.0;
+        }
+        double eps = epsFor(C, scoreMu);
+        double rho = ((double) nLast / nPrev) * eps;
+        if (rho <= 0 || rho >= 1) {
+            return 0.0;
+        }
+        return Math.min(nLast * Math.pow(eps, last - 1) * rho / (1 - rho), scoreMu);
+    }
+
+    /** M_m counts (index m = boundary size, 2..min(|C|, reserveDepth)); cached, mu-independent. */
+    int[] countsFor(BitSet C) {
+        int[] cached = countsCache.get(C);
+        if (cached != null) {
+            return cached;
+        }
+        int card = C.cardinality();
+        int[] n = new int[Math.min(card, reserveDepth) + 1];
+        if (card >= 2) {
+            List<BitSet> subs = subclades(C);
+            enumOps = 0;
+            for (int m = 2; m < n.length; m++) {
+                try {
+                    n[m] = countBoundaries(C, subs, m);
+                } catch (BudgetExceeded e) {
+                    break; // deeper orders omitted (negligible, like the tail)
+                }
+            }
+        }
+        countsCache.put(C, n);
+        return n;
+    }
+
+    private static double solveEps(int[] n, double mu) {
+        double lo = 0.0, hi = 1.0;
+        while (evalReserve(n, hi) < mu) {
+            hi *= 2.0;
+        }
+        for (int it = 0; it < 100; it++) {
+            double mid = 0.5 * (lo + hi);
+            if (evalReserve(n, mid) < mu) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        return 0.5 * (lo + hi);
+    }
+
+    /** {@code sum_{m>=2} n[m] x^(m-1)}. */
+    private static double evalReserve(int[] n, double x) {
+        double s = 0.0;
+        for (int m = 2; m < n.length; m++) {
+            if (n[m] > 0) {
+                s += n[m] * Math.pow(x, m - 1);
+            }
+        }
+        return s;
+    }
+
+    /** Count m-part boundaries of C into observed subclades, weighted by their all-novel pathcount. */
+    private int countBoundaries(BitSet C, List<BitSet> subs, int m) {
+        return enumerateBoundaries(C, subs, m, 0, BitSet.newBitSet(leafArraySize), new ArrayList<>(m));
+    }
+
+    private int enumerateBoundaries(BitSet C, List<BitSet> subs, int m, int startIdx,
+                                    BitSet used, List<BitSet> chosen) {
+        if (++enumOps > OPS_BUDGET) {
+            throw BUDGET_EXCEEDED;
+        }
+        if (chosen.size() == m - 1) {
+            BitSet last = BitSet.newBitSet(C);
+            last.andNot(used);
+            if (last.isEmpty() || !isObs(last)) {
+                return 0;
+            }
+            if (compareBitSets(chosen.get(chosen.size() - 1), last) >= 0) {
+                return 0; // canonical: the derived last part must be the largest
+            }
+            BitSet[] parts = new BitSet[m];
+            for (int i = 0; i < m - 1; i++) {
+                parts[i] = chosen.get(i);
+            }
+            parts[m - 1] = last;
+            return countAllNovelResolutions(C, parts);
+        }
+        int count = 0;
+        for (int i = startIdx; i < subs.size(); i++) {
+            BitSet pb = subs.get(i);
+            if (pb.intersects(used)) {
+                continue;
+            }
+            chosen.add(pb);
+            BitSet newUsed = BitSet.newBitSet(used);
+            newUsed.or(pb);
+            count += enumerateBoundaries(C, subs, m, i + 1, newUsed, chosen);
+            chosen.remove(chosen.size() - 1);
+        }
+        return count;
+    }
+
+    /**
+     * Number of all-novel binary resolutions of C into the given observed parts (subset DP over the
+     * parts). A split is allowed iff: at the region root (full mask = C, an observed clade) the split
+     * is unobserved (a real escape); at an intermediate node the clade itself is novel (a maximal
+     * region stops at observed clades, matching {@link #boundarySize}).
+     */
+    private int countAllNovelResolutions(BitSet C, BitSet[] parts) {
+        int k = parts.length;
+        if (k == 1) {
+            return 1;
+        }
+        int full = (1 << k) - 1;
+        BitSet[] unionOf = new BitSet[1 << k];
+        unionOf[0] = BitSet.newBitSet(leafArraySize);
+        for (int mask = 1; mask <= full; mask++) {
+            int low = Integer.numberOfTrailingZeros(mask);
+            BitSet u = BitSet.newBitSet(unionOf[mask & (mask - 1)]);
+            u.or(parts[low]);
+            unionOf[mask] = u;
+        }
+        int[] f = new int[1 << k];
+        for (int mask = 1; mask <= full; mask++) {
+            if (Integer.bitCount(mask) == 1) {
+                f[mask] = 1;
+                continue;
+            }
+            int low = mask & (-mask), rest = mask ^ low, count = 0;
+            for (int sub = rest; ; sub = (sub - 1) & rest) {
+                int s1 = sub | low, s2 = mask ^ s1;
+                if (s2 != 0 && splitAllowed(mask == full, unionOf[mask], unionOf[s1], unionOf[s2])) {
+                    count += f[s1] * f[s2];
+                }
+                if (sub == 0) {
+                    break;
+                }
+            }
+            f[mask] = count;
+        }
+        return f[full];
+    }
+
+    private boolean splitAllowed(boolean top, BitSet union, BitSet a, BitSet b) {
+        return top ? !isSplitObserved(union, a, b) : !isObs(union);
+    }
+
+    /* ----------------------------------------------------------------------
+     * Observed-backbone queries (over the inherited CCD1 clade DAG)
+     * ------------------------------------------------------------------- */
+
+    private boolean isObs(BitSet x) {
+        return getClade(x) != null; // leaves are clades too
+    }
+
+    private boolean isSplitObserved(BitSet parentBits, BitSet aBits, BitSet bBits) {
+        Clade parent = getClade(parentBits);
+        if (parent == null) {
+            return false;
+        }
+        Clade a = getClade(aBits);
+        Clade b = getClade(bBits);
+        if (a == null || b == null) {
+            return false;
+        }
+        return parent.getCladePartition(a, b) != null;
+    }
+
+    private double rawLogCCP(Clade parent, BitSet aBits, BitSet bBits) {
+        CladePartition p = parent.getCladePartition(getClade(aBits), getClade(bBits));
+        return p.getLogCCP();
+    }
+
+    /** Observed clades (incl. leaves) strictly contained in C, in canonical order; cached. */
+    private List<BitSet> subclades(BitSet C) {
+        return subCache.computeIfAbsent(C, c -> {
+            List<BitSet> out = new ArrayList<>();
+            int card = c.cardinality();
+            for (BitSet x : sortedCladeBits()) {
+                if (x.cardinality() < card && subset(x, c)) {
+                    out.add(x);
+                }
+            }
+            return out;
+        });
+    }
+
+    private List<BitSet> sortedCladeBits() {
+        if (sortedCladeBits == null) {
+            List<BitSet> all = new ArrayList<>();
+            for (Clade c : getClades()) {
+                all.add(c.getCladeInBits());
+            }
+            all.sort(MRegCCD::compareBitSets);
+            sortedCladeBits = all;
+        }
+        return sortedCladeBits;
+    }
+
+    /** Boundary size of the maximal region rooted at v: count of maximal observed/leaf subclades below. */
+    private int boundarySize(Node v, Map<Node, BitSet> bits) {
+        int m = 0;
+        for (Node child : v.getChildren()) {
+            if (child.isLeaf() || getClade(bits.get(child)) != null) {
+                m++;
+            } else {
+                m += boundarySize(child, bits);
+            }
+        }
+        return m;
+    }
+
+    private BitSet computeBits(Node v, Map<Node, BitSet> bits) {
+        BitSet b = BitSet.newBitSet(leafArraySize);
+        if (v.isLeaf()) {
+            b.set(v.getNr());
+        } else {
+            b.or(computeBits(v.getChildren().get(0), bits));
+            b.or(computeBits(v.getChildren().get(1), bits));
+        }
+        bits.put(v, b);
+        return b;
+    }
+
+    private static boolean subset(BitSet a, BitSet c) {
+        BitSet tmp = BitSet.newBitSet(a);
+        tmp.andNot(c);
+        return tmp.isEmpty();
+    }
+
+    /** Canonical total order on clade bitsets (lexicographic by set-bit indices). */
+    private static int compareBitSets(BitSet a, BitSet b) {
+        int ia = a.nextSetBit(0), ib = b.nextSetBit(0);
+        while (ia >= 0 && ib >= 0) {
+            if (ia != ib) {
+                return Integer.compare(ia, ib);
+            }
+            ia = a.nextSetBit(ia + 1);
+            ib = b.nextSetBit(ib + 1);
+        }
+        return Integer.compare(ia, ib);
+    }
+
+    /* ----------------------------------------------------------------------
+     * Sampling (self-consistent)
+     *
+     * The PIT calibration test draws trees from the model and needs only each draw's log-probability
+     * (not the tree object), so we override sampleTreeLogProbability() with a direct simulation of the
+     * generative process and never materialise a Tree. At each reservable clade we escape with
+     * probability equal to its escape mass (= mu by the eps-solve, tail EXCLUDED) and otherwise take
+     * an observed (red) split ~ CCP; an escape draws a region order m proportional to M_m eps^(m-1), a
+     * boundary of m observed subclades proportional to its all-novel pathcount, and recurses into the
+     * boundary parts. The resolution shape within a region is not drawn -- every shape has the same
+     * weight eps^(m-1) and does not change the draw's log-probability -- so the simulation is cheap.
+     *
+     * The draw distribution exactly matches getLogProbabilityOfTree when the model is built with the
+     * tail OFF (then the red discount is 1 - mu, matching the escape mass), for trees whose regions are
+     * within reserveDepth; deeper regions (mass ~mu^reserveDepth) are never produced, the same
+     * self-consistent / full-support trade-off KRegCCD makes for its PIT.
+     * ------------------------------------------------------------------- */
+
+    @Override
+    public double sampleTreeLogProbability() {
+        return simulate(getRootClade());
+    }
+
+    private double simulate(Clade c) {
+        if (c.isLeaf()) {
+            return 0.0;
+        }
+        BitSet cb = c.getCladeInBits();
+        if (reservable(cb)) {
+            double eps = epsFor(cb, mu);
+            int[] n = countsFor(cb);
+            double escapeMass = 0.0;
+            for (int m = 2; m < n.length; m++) {
+                if (n[m] > 0) {
+                    escapeMass += n[m] * Math.pow(eps, m - 1);
+                }
+            }
+            if (random.nextDouble() < escapeMass) {
+                int m = sampleOrder(n, eps, escapeMass);
+                BitSet[] parts = sampleBoundaryParts(cb, subclades(cb), m);
+                double logp = (m - 1) * Math.log(eps);
+                if (parts != null) {
+                    for (BitSet bp : parts) {
+                        logp += simulate(getClade(bp));
+                    }
+                }
+                return logp;
+            }
+            CladePartition p = samplePartition(c);
+            double logp = Math.log(1.0 - escapeMass) + p.getLogCCP();
+            return logp + simulate(p.getChildClades()[0]) + simulate(p.getChildClades()[1]);
+        }
+        CladePartition p = samplePartition(c); // non-reservable: observed split, no discount
+        return p.getLogCCP() + simulate(p.getChildClades()[0]) + simulate(p.getChildClades()[1]);
+    }
+
+    /** Draws a region order m in {2..} with probability proportional to {@code M_m eps^(m-1)}. */
+    private int sampleOrder(int[] n, double eps, double escapeMass) {
+        double target = random.nextDouble() * escapeMass, acc = 0.0;
+        for (int m = 2; m < n.length; m++) {
+            if (n[m] > 0) {
+                acc += n[m] * Math.pow(eps, m - 1);
+                if (target < acc) {
+                    return m;
+                }
+            }
+        }
+        for (int m = n.length - 1; m >= 2; m--) {
+            if (n[m] > 0) {
+                return m; // numerical guard
+            }
+        }
+        return 2;
+    }
+
+    /** Samples an observed (red) split of {@code c} with probability proportional to its CCP. */
+    private CladePartition samplePartition(Clade c) {
+        List<CladePartition> partitions = c.getPartitions();
+        double target = random.nextDouble(), acc = 0.0;
+        for (CladePartition p : partitions) {
+            acc += p.getCCP();
+            if (target < acc) {
+                return p;
+            }
+        }
+        return partitions.get(partitions.size() - 1);
+    }
+
+    /**
+     * Weighted-reservoir samples one boundary of {@code c} into {@code m} observed subclades,
+     * proportional to its all-novel pathcount (so that, combined with order sampling, every distinct
+     * novel resolution is equiprobable at {@code eps^(m-1)}). Returns the parts, or {@code null} if
+     * none/op-budget.
+     */
+    private BitSet[] sampleBoundaryParts(BitSet c, List<BitSet> subs, int m) {
+        boundaryPick = null;
+        boundaryWeightSeen = 0.0;
+        enumOps = 0;
+        try {
+            sampleBoundaryWalk(c, subs, m, 0, BitSet.newBitSet(leafArraySize), new ArrayList<>(m));
+        } catch (BudgetExceeded e) {
+            return boundaryPick; // whatever was picked before the cap (may be null)
+        }
+        return boundaryPick;
+    }
+
+    private BitSet[] boundaryPick;
+    private double boundaryWeightSeen;
+
+    private void sampleBoundaryWalk(BitSet c, List<BitSet> subs, int m, int startIdx,
+                                    BitSet used, List<BitSet> chosen) {
+        if (++enumOps > OPS_BUDGET) {
+            throw BUDGET_EXCEEDED;
+        }
+        if (chosen.size() == m - 1) {
+            BitSet last = BitSet.newBitSet(c);
+            last.andNot(used);
+            if (last.isEmpty() || !isObs(last)) {
+                return;
+            }
+            if (compareBitSets(chosen.get(chosen.size() - 1), last) >= 0) {
+                return;
+            }
+            BitSet[] parts = new BitSet[m];
+            for (int i = 0; i < m - 1; i++) {
+                parts[i] = chosen.get(i);
+            }
+            parts[m - 1] = last;
+            int pc = countAllNovelResolutions(c, parts);
+            if (pc <= 0) {
+                return;
+            }
+            boundaryWeightSeen += pc;
+            if (random.nextDouble() * boundaryWeightSeen < pc) { // weighted reservoir
+                boundaryPick = parts;
+            }
+            return;
+        }
+        for (int i = startIdx; i < subs.size(); i++) {
+            BitSet pb = subs.get(i);
+            if (pb.intersects(used)) {
+                continue;
+            }
+            chosen.add(pb);
+            BitSet newUsed = BitSet.newBitSet(used);
+            newUsed.or(pb);
+            sampleBoundaryWalk(c, subs, m, i + 1, newUsed, chosen);
+            chosen.remove(chosen.size() - 1);
+        }
+    }
+
+    @Override
+    public Tree sampleTree(HeightSettingStrategy heightStrategy) {
+        throw new UnsupportedOperationException(
+                "MRegCCD materialised-tree sampling is not implemented; sampleTreeLogProbability() "
+                        + "(used by the PIT) simulates draws without building trees.");
+    }
+}

--- a/src/main/java/ccd/model/NNIRegCCD.java
+++ b/src/main/java/ccd/model/NNIRegCCD.java
@@ -1,0 +1,162 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.algorithms.NNICladeExpansion.PairingMode;
+import ccd.algorithms.regularisation.CCD1Regularisor;
+import ccd.algorithms.regularisation.CCDExpansion;
+import ccd.algorithms.regularisation.CCDRegularisationStrategy;
+import ccd.algorithms.regularisation.NNICladeExpander;
+
+import java.util.List;
+
+/**
+ * A {@link RegCCD} whose clade set is additionally expanded with the clades
+ * reachable by a single nearest-neighbour-interchange (NNI) move (see
+ * {@link NNICladeExpander}).
+ *
+ * <p>
+ * Plain regCCD ({@link RegCCD}) assigns nonzero probability to trees with
+ * unsampled <em>splits</em> of sampled clades, but a tree containing an
+ * <em>unsampled clade</em> still gets zero probability. This class closes that
+ * gap at the clade level: it proposes the NNI-reachable novel clades, wires them
+ * into the graph with {@link CCDExpansion} exactly as for observed clades, and
+ * prices every split (observed, split-expanded, and NNI) with the same
+ * additive-{@code alpha} smoothing. No new free parameter is introduced --- the
+ * novel clades carry no marginal parameter, and their probability is induced by
+ * the CCD1 product of conditional clade probabilities.
+ * </p>
+ *
+ * <p>
+ * Pipeline:
+ * <ol>
+ * <li>build the CCD1 graph from the trees;</li>
+ * <li>split expansion ({@link CCDExpansion}) over observed clades, so NNI sees
+ * the full set of compatible observed-clade splits as recombination contexts;</li>
+ * <li>NNI clade expansion ({@link PairingMode}) --- add novel clades and their
+ * NNI-implied splits;</li>
+ * <li>split expansion ({@link CCDExpansion}) over all clades, now including
+ * compatible splits involving the novel clades;</li>
+ * <li>additive-{@code alpha} regularisation;</li>
+ * <li>finalise deterministic single-split novel clades.</li>
+ * </ol>
+ * </p>
+ *
+ * @author Claude (CCD-Sophie)
+ */
+public class NNIRegCCD extends RegCCD {
+
+    /** Default regularisation pseudocount, matching {@link RegCCD}. */
+    public static final double DEFAULT_ALPHA = 0.4;
+
+    private final PairingMode pairingMode;
+    private final double alpha;
+    /** Second pseudocount for NNI splits; NaN means single-alpha smoothing. */
+    private final double beta;
+    private NNICladeExpander cladeExpander;
+
+    /**
+     * @param trees  the trees whose distribution is approximated
+     * @param burnin fraction of given trees discarded as burn-in
+     * @param mode   how splits are paired into NNI recombinations
+     */
+    public NNIRegCCD(List<Tree> trees, double burnin, PairingMode mode) {
+        this(trees, burnin, mode, DEFAULT_ALPHA);
+    }
+
+    /**
+     * @param trees  the trees whose distribution is approximated
+     * @param burnin fraction of given trees discarded as burn-in
+     * @param mode   how splits are paired into NNI recombinations
+     * @param alpha  additive-smoothing pseudocount
+     */
+    public NNIRegCCD(List<Tree> trees, double burnin, PairingMode mode, double alpha) {
+        this(trees, burnin, mode, alpha, Double.NaN);
+    }
+
+    /**
+     * Two-level smoothing: NNI-derived splits get pseudocount {@code beta} while
+     * observed and split-expanded splits keep {@code alpha}. With {@code beta <
+     * alpha} the speculative NNI recombinations dilute observed splits less.
+     *
+     * @param trees  the trees whose distribution is approximated
+     * @param burnin fraction of given trees discarded as burn-in
+     * @param mode   how splits are paired into NNI recombinations
+     * @param alpha  pseudocount for observed and split-expanded splits
+     * @param beta   pseudocount for NNI-derived splits (NaN for single-alpha)
+     */
+    public NNIRegCCD(List<Tree> trees, double burnin, PairingMode mode, double alpha, double beta) {
+        super(trees, burnin, false);
+        this.pairingMode = mode;
+        this.alpha = alpha;
+        this.beta = beta;
+        nniPostConstruction();
+    }
+
+    /**
+     * @param treeSet trees without burn-in used to build the CCD
+     * @param mode    how splits are paired into NNI recombinations
+     * @param alpha   additive-smoothing pseudocount
+     */
+    public NNIRegCCD(TreeAnnotator.TreeSet treeSet, PairingMode mode, double alpha) {
+        this(treeSet, mode, alpha, Double.NaN);
+    }
+
+    /**
+     * @param treeSet trees without burn-in used to build the CCD
+     * @param mode    how splits are paired into NNI recombinations
+     * @param alpha   pseudocount for observed and split-expanded splits
+     * @param beta    pseudocount for NNI-derived splits (NaN for single-alpha)
+     */
+    public NNIRegCCD(TreeAnnotator.TreeSet treeSet, PairingMode mode, double alpha, double beta) {
+        super(treeSet, false);
+        this.pairingMode = mode;
+        this.alpha = alpha;
+        this.beta = beta;
+        nniPostConstruction();
+    }
+
+    private void nniPostConstruction() {
+        // 1. split expansion among observed clades, so NNI has the full set of
+        //    compatible observed-clade splits to recombine (GRAPH_WIDE picks up
+        //    novel clades from CCD0-expanded contexts that CCD1 would miss; for
+        //    CO_OCCURRING the enumeration walks base trees and is unaffected)
+        new CCDExpansion().expandCCD(this);
+
+        // 2. NNI clade expansion on the split-expanded observed graph
+        cladeExpander = new NNICladeExpander(pairingMode);
+        cladeExpander.expandClades(this);
+
+        // 3. split expansion over all clades (observed + novel), as in plain regCCD
+        new CCDExpansion().expandCCD(this);
+
+        // 3. regularisation over the full graph: single-alpha, or two-level alpha/beta
+        if (Double.isNaN(beta)) {
+            regulariseRegCCD(alpha);
+        } else {
+            new CCD1Regularisor(CCDRegularisationStrategy.AdditiveXY, alpha, beta).regularise(this);
+        }
+
+        // 4. finalise deterministic single-split novel clades (0/0 otherwise)
+        NNICladeExpander.fixZeroOccurrenceSingletonCCPs(this);
+
+        System.out.println("NNI clade expansion [" + pairingMode + "]: added "
+                + cladeExpander.getCladesAdded() + " clades; regularised with alpha = " + alpha
+                + (Double.isNaN(beta) ? "" : ", beta = " + beta));
+    }
+
+    /** @return the pairing mode used for the NNI clade expansion */
+    public PairingMode getPairingMode() {
+        return pairingMode;
+    }
+
+    /** @return the number of novel clades added by the NNI expansion */
+    public int getNumberOfNNIClades() {
+        return (cladeExpander == null) ? 0 : cladeExpander.getCladesAdded();
+    }
+
+    @Override
+    public String toString() {
+        return "NNI-expanded " + super.toString();
+    }
+}

--- a/src/main/java/ccd/model/OptRegCCD.java
+++ b/src/main/java/ccd/model/OptRegCCD.java
@@ -14,7 +14,7 @@ public class OptRegCCD extends RegCCD {
     /**
      * Constructor for an empty CCD. Trees can then be processed one by one.
      *
-     * @param numLeaves      number of leaves of the trees that this CCD will be based on
+     * @param numLeaves number of leaves of the trees that this CCD will be based on
      */
     public OptRegCCD(int numLeaves) {
         super(numLeaves);
@@ -37,9 +37,9 @@ public class OptRegCCD extends RegCCD {
      * Constructor for a {@link OptRegCCD} based on the given collection of trees
      * (not containing any burnin trees).
      *
-     * @param treeSet        an iterable set of trees, which contains no burnin trees,
-     *                       whose distribution is approximated by the resulting
-     *                       {@link OptRegCCD}; all of its trees are used
+     * @param treeSet an iterable set of trees, which contains no burnin trees,
+     *                whose distribution is approximated by the resulting
+     *                {@link OptRegCCD}; all of its trees are used
      */
     public OptRegCCD(TreeAnnotator.TreeSet treeSet) {
         super(treeSet);
@@ -62,7 +62,9 @@ public class OptRegCCD extends RegCCD {
         UnivariateFunction f = RegCCDParameterOptimiser.defineFunction(this, this.baseTrees);
         double threshold = 1e-6;
         double startingPoint;
-        do { startingPoint = Math.random(); } while (startingPoint == 0.0);
+        do {
+            startingPoint = Math.random();
+        } while (startingPoint == 0.0);
         double optiAlpha = RegCCDParameterOptimiser.optimise(f, threshold, threshold, 200, startingPoint);
         return optiAlpha;
     }

--- a/src/main/java/ccd/model/RegCCD.java
+++ b/src/main/java/ccd/model/RegCCD.java
@@ -5,6 +5,7 @@ import beastfx.app.treeannotator.TreeAnnotator;
 import ccd.algorithms.regularisation.CCDExpansion;
 import ccd.algorithms.regularisation.CCD1Regularisor;
 import ccd.algorithms.regularisation.CCDRegularisationStrategy;
+
 import java.util.List;
 
 public class RegCCD extends CCD1 {
@@ -12,7 +13,7 @@ public class RegCCD extends CCD1 {
     /**
      * Constructor for an empty CCD. Trees can then be processed one by one.
      *
-     * @param numLeaves      number of leaves of the trees that this CCD will be based on
+     * @param numLeaves number of leaves of the trees that this CCD will be based on
      */
     public RegCCD(int numLeaves) {
         super(numLeaves, true);
@@ -28,21 +29,62 @@ public class RegCCD extends CCD1 {
      *               should be discarded as burn-in
      */
     public RegCCD(List<Tree> trees, double burnin) {
+        this(trees, burnin, true);
+    }
+
+    /**
+     * Constructor for a {@link RegCCD} with a custom regularisation pseudocount.
+     *
+     * @param trees  the trees whose distribution is approximated
+     * @param burnin fraction of given trees discarded as burn-in
+     * @param alpha  additive-smoothing pseudocount
+     */
+    public RegCCD(List<Tree> trees, double burnin, double alpha) {
+        this(trees, burnin, false);
+        expandRegCCD();
+        regulariseRegCCD(alpha);
+    }
+
+    /**
+     * Constructor for a {@link RegCCD} based on the given collection of trees,
+     * optionally deferring the expand/regularise pipeline so subclasses can
+     * insert further graph expansion before regularising.
+     *
+     * @param trees              the trees whose distribution is approximated
+     * @param burnin             fraction of given trees discarded as burn-in
+     * @param runPostConstruction whether to run expand + regularise now
+     */
+    protected RegCCD(List<Tree> trees, double burnin, boolean runPostConstruction) {
         super(trees, burnin);
-        postConstruction();
+        if (runPostConstruction) {
+            postConstruction();
+        }
     }
 
     /**
      * Constructor for a {@link RegCCD} based on the given collection of trees
      * (not containing any burnin trees).
      *
-     * @param treeSet        an iterable set of trees, which contains no burnin trees,
-     *                       whose distribution is approximated by the resulting
-     *                       {@link RegCCD}; all of its trees are used
+     * @param treeSet an iterable set of trees, which contains no burnin trees,
+     *                whose distribution is approximated by the resulting
+     *                {@link RegCCD}; all of its trees are used
      */
     public RegCCD(TreeAnnotator.TreeSet treeSet) {
+        this(treeSet, true);
+    }
+
+    /**
+     * Constructor for a {@link RegCCD} based on the given tree set, optionally
+     * deferring the expand/regularise pipeline.
+     *
+     * @param treeSet             trees without burn-in used to build the CCD
+     * @param runPostConstruction whether to run expand + regularise now
+     */
+    protected RegCCD(TreeAnnotator.TreeSet treeSet, boolean runPostConstruction) {
         super(treeSet, true);
-        postConstruction();
+        if (runPostConstruction) {
+            postConstruction();
+        }
     }
 
     protected void postConstruction() {
@@ -62,7 +104,11 @@ public class RegCCD extends CCD1 {
     }
 
     public void regulariseRegCCD() {
-        CCD1Regularisor regulariser = new CCD1Regularisor(CCDRegularisationStrategy.AdditiveX, 0.4);
+        regulariseRegCCD(0.4);
+    }
+
+    public void regulariseRegCCD(double alpha) {
+        CCD1Regularisor regulariser = new CCD1Regularisor(CCDRegularisationStrategy.AdditiveX, alpha);
         regulariser.regularise(this);
     }
 }

--- a/src/main/java/ccd/model/SJSupport.java
+++ b/src/main/java/ccd/model/SJSupport.java
@@ -1,0 +1,458 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import ccd.model.bitsets.BitSet;
+
+import java.util.ArrayList;
+
+/**
+ * Shared logic for the extended-split (SJ) sampled-ancestor clade identity,
+ * factored out so {@link CCD1SJ} and {@link CCD0SJ} share one implementation
+ * (Java's single-inheritance forces them to extend different parents).
+ *
+ * <p>The SJ identity (per {@code alexei_c_four_sa_models.pdf}, Table 1):
+ * each internal clade carries SA flags for its direct leaf children only,
+ * with no propagation up the tree. Identity bitset width is {@code 2n+1}:
+ * <ul>
+ *   <li>bits {@code [0, n)}: taxa membership
+ *   <li>bits {@code [n, 2n)}: bit {@code n+i} set iff leaf {@code i} is a
+ *       direct SA leaf child of this clade
+ *   <li>bit {@code 2n}: sentinel for the placeholder root clade
+ * </ul>
+ *
+ * <p>The placeholder {@code rootClade} carries one
+ * {@code (variant, emptyClade)} partition per observed root variant; the
+ * shared {@code emptyClade} is a neutral sister with no taxa.
+ *
+ * <p>All methods are static and package-private. State is passed in
+ * explicitly via the {@link AbstractCCD} parameter (whose protected fields
+ * are accessible from this same package) and the {@code emptyClade}
+ * argument.
+ */
+final class SJSupport {
+
+    private SJSupport() {
+    }
+
+    /**
+     * Bitset width used for all clades under the SJ identity: {@code 2n + 1}
+     * (taxa bits, SA-flag bits, sentinel bit).
+     */
+    static int extendedBitWidth(int leafArraySize) {
+        return 2 * leafArraySize + 1;
+    }
+
+    /* -- KEY CONSTRUCTION -- */
+
+    /**
+     * Bitset key for a leaf clade: only the taxon bit is set (SA flags live
+     * on the parent under the SJ identity, not on the leaf itself).
+     */
+    static BitSet leafKey(int taxonIndex, int leafArraySize) {
+        BitSet key = BitSet.newBitSet(extendedBitWidth(leafArraySize));
+        key.set(taxonIndex);
+        return key;
+    }
+
+    /**
+     * Bitset key for an internal clade under the SJ identity: union of
+     * descendant taxa bits, plus an SA-flag bit for each direct leaf child of
+     * this vertex with branch length zero. SA flags do not propagate up.
+     */
+    static BitSet extendedSelfKey(Node vertex, int leafArraySize) {
+        BitSet key = BitSet.newBitSet(extendedBitWidth(leafArraySize));
+        collectTaxaBits(vertex, key);
+        for (Node child : vertex.getChildren()) {
+            if (child.isLeaf() && child.getLength() == 0) {
+                key.set(leafArraySize + child.getNr());
+            }
+        }
+        return key;
+    }
+
+    private static void collectTaxaBits(Node vertex, BitSet key) {
+        if (vertex.isLeaf()) {
+            key.set(vertex.getNr());
+        } else {
+            for (Node child : vertex.getChildren()) {
+                collectTaxaBits(child, key);
+            }
+        }
+    }
+
+    /* -- ROOT INITIALISATION -- */
+
+    /**
+     * Sets up the placeholder root clade (sentinel bit only) and the shared
+     * empty sister, registers both in {@code ccd.cladeMapping}, and returns
+     * the empty sister so the caller can store the field reference. Must be
+     * invoked from the subclass's {@code initializeRootClade} override.
+     */
+    static Clade initializeSJRoot(AbstractCCD ccd, int numLeaves) {
+        ccd.leafArraySize = numLeaves;
+        int width = extendedBitWidth(numLeaves);
+
+        BitSet rootBitSet = BitSet.newBitSet(width);
+        rootBitSet.set(2 * numLeaves);
+        ccd.rootClade = new Clade(rootBitSet, ccd);
+        ccd.cladeMapping.put(ccd.rootClade.getCladeInBits(), ccd.rootClade);
+
+        BitSet emptyKey = BitSet.newBitSet(width);
+        return ccd.addNewClade(emptyKey);
+    }
+
+    /* -- TREE INSERTION -- */
+
+    /**
+     * Top-level cladify entry: walks the tree under the SJ identity and
+     * attaches the resulting root variant to {@code ccd.rootClade} via a
+     * {@code (variant, emptyClade)} partition. Increments the placeholder
+     * root's occurrence count once per tree.
+     */
+    static Clade cladifyTreeRoot(AbstractCCD ccd, Clade emptyClade, Node root) {
+        return cladifySJVertex(ccd, emptyClade, root, true);
+    }
+
+    private static Clade cladifySJVertex(AbstractCCD ccd, Clade emptyClade, Node vertex, boolean isRoot) {
+        if (vertex.isLeaf()) {
+            BitSet leafKey = leafKey(vertex.getNr(), ccd.leafArraySize);
+            Clade leafClade = ccd.cladeMapping.get(leafKey);
+            if (leafClade == null) {
+                leafClade = ccd.addNewClade(leafKey);
+            }
+            leafClade.increaseOccurrenceCount(vertex.getHeight());
+            return leafClade;
+        }
+
+        Clade firstChildClade = cladifySJVertex(ccd, emptyClade, vertex.getChildren().get(0), false);
+        Clade secondChildClade = cladifySJVertex(ccd, emptyClade, vertex.getChildren().get(1), false);
+
+        BitSet selfKey = extendedSelfKey(vertex, ccd.leafArraySize);
+        Clade currentClade = ccd.cladeMapping.get(selfKey);
+        if (currentClade == null) {
+            currentClade = ccd.addNewClade(selfKey);
+        }
+        currentClade.increaseOccurrenceCount(vertex.getHeight());
+
+        CladePartition partition = currentClade.getCladePartition(firstChildClade, secondChildClade);
+        if (partition == null) {
+            partition = currentClade.createCladePartition(firstChildClade, secondChildClade);
+        }
+        partition.increaseOccurrenceCount(vertex.getHeight());
+
+        if (isRoot) {
+            // Attach this root variant under the placeholder rootClade via a
+            // (variant, emptyClade) partition. rootClade's own occurrence
+            // count ticks up once per tree.
+            ccd.rootClade.increaseOccurrenceCount(vertex.getHeight());
+            CladePartition rootPart = ccd.rootClade.getCladePartition(currentClade, emptyClade);
+            if (rootPart == null) {
+                rootPart = ccd.rootClade.createCladePartition(currentClade, emptyClade);
+            }
+            rootPart.increaseOccurrenceCount(vertex.getHeight());
+        }
+
+        return currentClade;
+    }
+
+    /* -- SA DETECTION & DISPLAY -- */
+
+    /**
+     * True iff the clade has at least one direct sampled-ancestor leaf
+     * child (any bit set in the SA region {@code [n, 2n)}).
+     */
+    static boolean isSampledAncestor(Clade clade, int leafArraySize) {
+        BitSet bits = clade.getCladeInBits();
+        for (int i = leafArraySize; i < 2 * leafArraySize; i++) {
+            if (bits.get(i)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Renders the clade's SA-flag region as a human-readable string for
+     * inclusion in {@link Clade#toString()}.
+     */
+    static String saInfoString(Clade clade, int leafArraySize) {
+        BitSet bits = clade.getCladeInBits();
+        java.util.List<Integer> sa = new ArrayList<>();
+        for (int i = leafArraySize; i < 2 * leafArraySize; i++) {
+            if (bits.get(i)) sa.add(i - leafArraySize);
+        }
+        if (sa.isEmpty()) return "sampled ancestor = none";
+        return "sampled ancestor taxa = " + sa;
+    }
+
+    /* -- SJ-FLAG COMPATIBILITY (used by CCD0SJ.expand) -- */
+
+    /**
+     * True iff the partition {@code (A, B)} is consistent with
+     * {@code parent}'s SA-flag identity: every SA-flagged leaf {@code l} of
+     * {@code parent} must appear as the singleton clade {@code {l}} in
+     * {@code A} or {@code B}. Used to filter expanded partitions so the
+     * model never assigns probability to trees that violate the identity.
+     */
+    static boolean isSJCompatible(Clade parent, Clade A, Clade B, int leafArraySize) {
+        BitSet bits = parent.getCladeInBits();
+        for (int i = leafArraySize; i < 2 * leafArraySize; i++) {
+            if (!bits.get(i)) continue;
+            int taxon = i - leafArraySize;
+            boolean aIsSingletonForTaxon = A.size() == 1 && A.getCladeInBitsTaxaOnly().get(taxon);
+            boolean bIsSingletonForTaxon = B.size() == 1 && B.getCladeInBitsTaxaOnly().get(taxon);
+            if (!aIsSingletonForTaxon && !bIsSingletonForTaxon) return false;
+        }
+        return true;
+    }
+
+    /* -- TREE PROBABILITY -- */
+
+    /**
+     * Computes {@code P(T)} (or its log) by walking {@code root} under the
+     * SJ identity and folding in CCPs along the path, including the
+     * placeholder root's {@code (variant, emptyClade)} factor. Returns the
+     * variant clade for the tree's root, or {@code null} if any vertex's
+     * extended clade or partition isn't in the model.
+     */
+    static Clade computeTreeProbability(AbstractCCD ccd, Clade emptyClade, Node root,
+                                        double[] runningProbability, boolean computeLog) {
+        Clade variant = computeProbSJVertex(ccd, root, runningProbability, computeLog);
+        if (variant == null) return null;
+        CladePartition rootPart = ccd.rootClade.getCladePartition(variant, emptyClade);
+        if (rootPart == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+        if (computeLog) {
+            runningProbability[0] += rootPart.getLogCCP();
+        } else {
+            runningProbability[0] *= rootPart.getCCP();
+        }
+        return variant;
+    }
+
+    private static Clade computeProbSJVertex(AbstractCCD ccd, Node vertex,
+                                             double[] runningProbability, boolean computeLog) {
+        if (vertex.isLeaf()) {
+            BitSet leafKey = leafKey(vertex.getNr(), ccd.leafArraySize);
+            Clade leafClade = ccd.cladeMapping.get(leafKey);
+            if (leafClade == null) {
+                AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+                return null;
+            }
+            return leafClade;
+        }
+
+        Clade firstChildClade = computeProbSJVertex(ccd, vertex.getChildren().get(0), runningProbability, computeLog);
+        Clade secondChildClade = computeProbSJVertex(ccd, vertex.getChildren().get(1), runningProbability, computeLog);
+
+        if (firstChildClade == null || secondChildClade == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        BitSet selfKey = extendedSelfKey(vertex, ccd.leafArraySize);
+        Clade currentClade = ccd.cladeMapping.get(selfKey);
+        if (currentClade == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        CladePartition partition = currentClade.getCladePartition(firstChildClade, secondChildClade);
+        if (partition == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        if (computeLog) {
+            runningProbability[0] += partition.getLogCCP();
+        } else {
+            runningProbability[0] *= partition.getCCP();
+        }
+        return currentClade;
+    }
+
+    /* -- HELD-OUT (LEAVE-ONE-TREE-OUT) TREE PROBABILITY -- */
+
+    /**
+     * Leave-one-tree-out counterpart of {@link #computeTreeProbability}: folds
+     * in the held-out CCPs {@code (count-1+alpha)/(parentCount+alpha*k-1)}
+     * instead of the in-sample CCPs, so the returned value is
+     * {@code P(T | CCD trained on all trees except T)}. Mirrors the EL/CP
+     * held-out traversal in {@link CCD1#getLogProbOfHeldOutTree}: a clade or
+     * partition seen only in the held-out tree contributes no probability.
+     */
+    static Clade computeTreeProbabilityHeldOut(AbstractCCD ccd, Clade emptyClade, Node root, double[] runningProbability, double alpha, boolean computeLog) {
+        Clade variant = computeProbSJVertexHeldOut(ccd, root, runningProbability, alpha, computeLog);
+        if (variant == null) return null;
+        CladePartition rootPart = ccd.rootClade.getCladePartition(variant, emptyClade);
+        if (rootPart == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+        if (computeLog) {
+            runningProbability[0] += rootPart.getLogCCPInHeldOutTree(alpha);
+        } else {
+            runningProbability[0] *= rootPart.getCCPInHeldOutTree(alpha);
+        }
+        return variant;
+    }
+
+    private static Clade computeProbSJVertexHeldOut(AbstractCCD ccd, Node vertex, double[] runningProbability, double alpha, boolean computeLog) {
+        if (vertex.isLeaf()) {
+            BitSet leafKey = leafKey(vertex.getNr(), ccd.leafArraySize);
+            Clade leafClade = ccd.cladeMapping.get(leafKey);
+            if (leafClade == null) {
+                AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+                return null;
+            }
+            return leafClade;
+        }
+
+        Clade firstChildClade = computeProbSJVertexHeldOut(ccd, vertex.getChildren().get(0), runningProbability, alpha, computeLog);
+        Clade secondChildClade = computeProbSJVertexHeldOut(ccd, vertex.getChildren().get(1), runningProbability, alpha, computeLog);
+
+        if (firstChildClade == null || secondChildClade == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        BitSet selfKey = extendedSelfKey(vertex, ccd.leafArraySize);
+        Clade currentClade = ccd.cladeMapping.get(selfKey);
+        // A clade seen in exactly one tree exists only because of the held-out
+        // tree; the held-out model has never seen it, so contribute no probability
+        // (also avoids a zero denominator in the held-out CCP at alpha=0).
+        if (currentClade == null || currentClade.getNumberOfOccurrences() == 1) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        CladePartition partition = currentClade.getCladePartition(firstChildClade, secondChildClade);
+        if (partition == null) {
+            AbstractCCD.setComputedNoProbability(runningProbability, computeLog);
+            return null;
+        }
+
+        if (computeLog) {
+            runningProbability[0] += partition.getLogCCPInHeldOutTree(alpha);
+        } else {
+            runningProbability[0] *= partition.getCCPInHeldOutTree(alpha);
+        }
+        return currentClade;
+    }
+
+    /* -- SAMPLING & MAP -- */
+
+    /**
+     * Builds a tree under the SJ identity: pick a root variant via the
+     * placeholder root's {@code (variant, emptyClade)} partitions, then
+     * recursively pick partitions on the variant's subtree.
+     *
+     * <p><b>TODO — height strategy not yet supported.</b> Heights are always
+     * assigned with the "One" semantics (parent = max(child) + 1, SA leaves
+     * get parent height for branch length zero), regardless of the
+     * {@code heightStrategy} argument. Implementing
+     * {@code MeanOccurredHeights} / {@code CommonAncestorHeights} correctly
+     * under SJ requires per-SA-context height stats: a leaf can appear as
+     * an SA child in some trees and a non-SA child in others, and
+     * {@link Clade#getMeanOccurredHeight()} averages over both, which is
+     * the wrong number whichever way you use it.
+     */
+    static Tree buildTree(AbstractCCD ccd, Clade emptyClade,
+                          SamplingStrategy samplingStrategy, HeightSettingStrategy heightStrategy) {
+        ccd.tidyUpCacheIfDirty();
+
+        CladePartition rootPart = pickRootPartition(ccd, emptyClade, samplingStrategy);
+        Clade variant = variantChildOf(rootPart, emptyClade);
+
+        int[] innerIdx = new int[]{ccd.getSizeOfLeavesArray()};
+        Node root = buildSubtree(ccd, variant, samplingStrategy, innerIdx);
+        return new Tree(root);
+    }
+
+    private static Clade variantChildOf(CladePartition partition, Clade emptyClade) {
+        Clade[] kids = partition.getChildClades();
+        return (kids[0] == emptyClade) ? kids[1] : kids[0];
+    }
+
+    private static CladePartition pickRootPartition(AbstractCCD ccd, Clade emptyClade, SamplingStrategy strategy) {
+        ArrayList<CladePartition> partitions = ccd.rootClade.getPartitions();
+        if (partitions.isEmpty()) {
+            throw new AssertionError("SJ rootClade has no variant partitions.");
+        }
+        if (strategy == SamplingStrategy.MAP) {
+            double bestScore = Double.NEGATIVE_INFINITY;
+            CladePartition best = partitions.get(0);
+            for (CladePartition p : partitions) {
+                Clade variant = variantChildOf(p, emptyClade);
+                double score = Math.log(p.getCCP()) + variant.getMaxSubtreeLogCCP();
+                if (score > bestScore) {
+                    bestScore = score;
+                    best = p;
+                }
+            }
+            return best;
+        }
+        return weightedDraw(partitions, ccd);
+    }
+
+    private static Node buildSubtree(AbstractCCD ccd, Clade clade, SamplingStrategy strategy, int[] innerIdx) {
+        if (clade.isLeaf()) {
+            int leafNr = clade.getCladeInBits().nextSetBit(0);
+            String taxonName = ccd.getSomeBaseTree().getTaxaNames()[leafNr];
+            Node node = new Node(taxonName);
+            node.setNr(leafNr);
+            return node;
+        }
+
+        CladePartition partition = pickInternalPartition(ccd, clade, strategy);
+        if (partition == null) {
+            throw new AssertionError("No partitions on clade: " + clade.getCladeInBits());
+        }
+
+        Node firstChild = buildSubtree(ccd, partition.getChildClades()[0], strategy, innerIdx);
+        Node secondChild = buildSubtree(ccd, partition.getChildClades()[1], strategy, innerIdx);
+
+        Node node = new Node();
+        node.setNr(innerIdx[0]++);
+        node.addChild(firstChild);
+        node.addChild(secondChild);
+
+        // "One" height semantics: parent = max(children) + 1; SA leaves get
+        // parent's height (branch length 0).
+        double parentHeight = Math.max(safeHeight(firstChild), safeHeight(secondChild)) + 1.0;
+        node.setHeight(parentHeight);
+
+        for (Node child : node.getChildren()) {
+            if (child.isLeaf()) {
+                int leafNr = child.getNr();
+                boolean isSA = clade.getCladeInBits().get(ccd.leafArraySize + leafNr);
+                child.setHeight(isSA ? parentHeight : 0.0);
+            }
+        }
+        return node;
+    }
+
+    private static CladePartition pickInternalPartition(AbstractCCD ccd, Clade clade, SamplingStrategy strategy) {
+        if (strategy == SamplingStrategy.MAP) {
+            return clade.getMaxSubtreeCCPPartition();
+        }
+        return weightedDraw(clade.getPartitions(), ccd);
+    }
+
+    private static CladePartition weightedDraw(ArrayList<CladePartition> partitions, AbstractCCD ccd) {
+        double total = 0;
+        for (CladePartition p : partitions) total += p.getCCP();
+        double r = ccd.random.nextDouble() * total;
+        double cum = 0;
+        for (CladePartition p : partitions) {
+            cum += p.getCCP();
+            if (r < cum) return p;
+        }
+        return partitions.get(partitions.size() - 1);
+    }
+
+    private static double safeHeight(Node n) {
+        return n.isLeaf() ? 0.0 : n.getHeight();
+    }
+}

--- a/src/main/java/ccd/model/SampleDistribution.java
+++ b/src/main/java/ccd/model/SampleDistribution.java
@@ -290,6 +290,26 @@ public class SampleDistribution implements ITreeDistribution {
     }
 
     @Override
+    public double sampleTreeLogProbability() {
+        this.tidyUpIfDirty();
+
+        int pick = this.getRandom().nextInt(numBaseTrees);
+        int next = 0;
+
+        for (WrappedBeastTree tree : trees) {
+            next += tree.getCount();
+
+            if (pick <= next) {
+                double p = tree.getCount() / (double) this.numBaseTrees;
+                return Math.log(p);
+            }
+        }
+
+        System.err.println("No tree probability sampled. Suspect number of tree counts does not add up to number of base trees.");
+        return Double.NEGATIVE_INFINITY;
+    }
+
+    @Override
     public int getNumberOfLeaves() {
         return numLeaves;
     }
@@ -408,6 +428,12 @@ public class SampleDistribution implements ITreeDistribution {
             }
         }
         return 0;
+    }
+
+    @Override
+    public double getLogProbabilityOfTree(Tree tree) {
+        double p = getProbabilityOfTree(tree);
+        return Math.log(p);
     }
 
     @Override
@@ -561,7 +587,6 @@ public class SampleDistribution implements ITreeDistribution {
             System.out.println("parent = " + vertex);
             System.out.println("childR = " + vertex.getRight());
         }
-
 
         leftBits.or(rightBits);
         return leftBits;

--- a/src/main/java/ccd/model/UniformEscapeCCD.java
+++ b/src/main/java/ccd/model/UniformEscapeCCD.java
@@ -1,0 +1,265 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beastfx.app.treeannotator.TreeAnnotator.TreeSet;
+
+import java.math.BigInteger;
+import java.util.List;
+
+/**
+ * The <em>trivial</em> full-support baseline: a plain {@link CCD1} backbone with a single lump of
+ * escape mass {@code epsilon} spread <em>uniformly</em> over every rooted topology the backbone does
+ * not already cover.
+ *
+ * <p>
+ * It exists to make one point precise. A {@link CCD1} (sampled splits only) assigns probability
+ * <em>exactly zero</em> to any tree containing an unseen clade or split, so on held-out data it has a
+ * coverage hole and an infinite cross-entropy. Full coverage <em>by itself</em> is trivial to buy:
+ * reserve a total mass {@code epsilon} and divide it equally among the
+ * {@code M = (2n-3)!! - K} topologies outside the backbone's support, where {@code K} is the number
+ * of topologies the backbone covers and {@code (2n-3)!!} is the number of rooted topologies on
+ * {@code n} taxa. Concretely, for a tree {@code T},
+ * <pre>
+ *   P(T) = (1 - epsilon) * P_CCD1(T)   if T is in the backbone's support,
+ *        = epsilon / M                  otherwise.
+ * </pre>
+ * The mass is exactly normalised: {@code (1 - epsilon) * 1 + M * (epsilon / M) = 1}.
+ *
+ * <p>
+ * Because every off-support tree shares the same minimal probability {@code epsilon / M}, this model
+ * is a deliberate <em>strawman</em>. Under the PIT / credible-level statistic
+ * {@code u(T) = P_{S~q}[ q(S) >= q(T) ]}, every held-out tree with novel structure scores the global
+ * minimum probability and so lands at {@code u ≈ 1} — they all pile into the top PIT bin (for
+ * {@code epsilon} smaller than the bin width), producing a calibration spike. And on held-out
+ * likelihood each novel tree costs {@code log(epsilon) - log(M) ≈ -log((2n-3)!!)} nats — finite, but
+ * catastrophically negative because the escape budget is smeared uniformly over an astronomically
+ * large set instead of being concentrated near the observed trees.
+ *
+ * <p>
+ * That contrast is the point: {@link KRegCCD} reaches full support with the <em>same</em> kind of
+ * escape budget but places it <em>structurally</em> (geometric in tree distance, concentrated near
+ * the sample), which both flattens the PIT and keeps the held-out likelihood high. This class is the
+ * uniform-placement control that isolates "structural placement" as the source of KRegCCD's
+ * advantage.
+ *
+ * <h3>Scope and assumptions</h3>
+ * The topology count {@code (2n-3)!!} is for fully resolved rooted bifurcating trees on {@code n}
+ * labelled taxa (no sampled ancestors, no polytomies) — the setting of the PIT / RSV2 held-out
+ * experiments. The escape probability is reported via the log, since {@code M} overflows
+ * {@code double} for even modest {@code n}; the linear {@link #getProbabilityOfTree(Tree)} of an
+ * off-support tree therefore underflows to {@code 0} for large {@code n} while
+ * {@link #getLogProbabilityOfTree(Tree)} stays finite (that is what the held-out / PIT drivers use).
+ *
+ * <h3>Sampling</h3>
+ * {@link #sampleTreeLogProbability()} and {@link #sampleTreeProbability()} correctly sample the full
+ * mixture (an {@code epsilon} fraction returns the escape value), which is all the PIT reference
+ * distribution needs. {@link #sampleTree()} is inherited and returns a concrete topology from the
+ * CCD1 backbone only — it does not synthesise the astronomically many escape topologies. This baseline
+ * is a held-out <em>scoring</em> device, not a generative model.
+ *
+ * @author Alexei Drummond
+ */
+public class UniformEscapeCCD extends CCD1 {
+
+    /** Total escape mass reserved for (and spread uniformly over) the off-support topologies. */
+    private final double escapeMass;
+
+    /** Precomputed {@code log(1 - escapeMass)}, the discount applied to every in-support tree. */
+    private final double log1mEscapeMass;
+
+    /**
+     * Cached escape log-probability {@code log(epsilon) - log(M)} and the backbone topology count
+     * {@code K} it was computed for; recomputed lazily if {@code K} changes (e.g. trees added later).
+     * {@link Double#NEGATIVE_INFINITY} means there are no off-support topologies, so the model
+     * collapses to the plain CCD1 backbone.
+     */
+    private double escapeLogProbCache = Double.NaN;
+    private BigInteger cachedSupportSize = null;
+
+    /* -- CONSTRUCTORS -- */
+
+    /**
+     * Constructor from a collection of trees with burn-in.
+     *
+     * @param trees      the trees whose CCD1 backbone is escape-smoothed
+     * @param burnin     fraction in {@code [0,1]} of leading trees discarded as burn-in
+     * @param escapeMass total escape mass {@code epsilon} spread uniformly over the off-support
+     *                   topologies; must be in {@code [0,1)}
+     */
+    public UniformEscapeCCD(List<Tree> trees, double burnin, double escapeMass) {
+        super(trees, burnin);
+        this.escapeMass = checkEscapeMass(escapeMass);
+        this.log1mEscapeMass = Math.log(1.0 - this.escapeMass);
+    }
+
+    /**
+     * Constructor from a tree set.
+     *
+     * @param treeSet    an iterable set of trees with no burn-in
+     * @param escapeMass total escape mass {@code epsilon} in {@code [0,1)}
+     */
+    public UniformEscapeCCD(TreeSet treeSet, double escapeMass) {
+        super(treeSet, true);
+        this.escapeMass = checkEscapeMass(escapeMass);
+        this.log1mEscapeMass = Math.log(1.0 - this.escapeMass);
+    }
+
+    /**
+     * Constructor for an empty CCD (trees added later or via {@link #copy()}).
+     *
+     * @param numLeaves      number of leaves of the trees this CCD will be based on
+     * @param storeBaseTrees whether to store the trees used to build this CCD
+     * @param escapeMass     total escape mass {@code epsilon} in {@code [0,1)}
+     */
+    public UniformEscapeCCD(int numLeaves, boolean storeBaseTrees, double escapeMass) {
+        super(numLeaves, storeBaseTrees);
+        this.escapeMass = checkEscapeMass(escapeMass);
+        this.log1mEscapeMass = Math.log(1.0 - this.escapeMass);
+    }
+
+    private static double checkEscapeMass(double escapeMass) {
+        if (!(escapeMass >= 0.0 && escapeMass < 1.0)) {
+            throw new IllegalArgumentException("escapeMass must be in [0, 1), but was " + escapeMass);
+        }
+        return escapeMass;
+    }
+
+    /* -- ESCAPE BOOKKEEPING -- */
+
+    /** @return the total escape mass {@code epsilon}. */
+    public double getEscapeMass() {
+        return escapeMass;
+    }
+
+    /** @return the number of rooted topologies outside the backbone's support, {@code (2n-3)!! - K}. */
+    public BigInteger getNumberOfOffSupportTrees() {
+        return numberOfRootedTopologies(getNumberOfLeaves()).subtract(super.getNumberOfTrees());
+    }
+
+    /**
+     * @return the (natural) log-probability of any single off-support tree, {@code log(epsilon/M)};
+     * {@link Double#NEGATIVE_INFINITY} if the backbone already covers every topology.
+     */
+    public double getEscapeLogProbability() {
+        BigInteger k = super.getNumberOfTrees();
+        if (cachedSupportSize == null || !cachedSupportSize.equals(k)) {
+            cachedSupportSize = k;
+            BigInteger offSupport = numberOfRootedTopologies(getNumberOfLeaves()).subtract(k);
+            escapeLogProbCache = (escapeMass <= 0.0 || offSupport.signum() <= 0)
+                    ? Double.NEGATIVE_INFINITY
+                    : Math.log(escapeMass) - logBigInteger(offSupport);
+        }
+        return escapeLogProbCache;
+    }
+
+    /* -- PROBABILITY -- */
+
+    @Override
+    public double getProbabilityOfTree(Tree tree) {
+        double p = super.getProbabilityOfTree(tree);
+        if (p > 0) {
+            return (1.0 - escapeMass) * p;
+        }
+        double escapeLogProb = getEscapeLogProbability();
+        return Double.isFinite(escapeLogProb) ? Math.exp(escapeLogProb) : 0.0;
+    }
+
+    @Override
+    public double getLogProbabilityOfTree(Tree tree) {
+        double logP = super.getLogProbabilityOfTree(tree);
+        if (Double.isFinite(logP)) {
+            return log1mEscapeMass + logP;
+        }
+        return getEscapeLogProbability();
+    }
+
+    @Override
+    public boolean containsTree(Tree tree) {
+        // Full support: with positive escape mass every rooted topology has positive probability.
+        // With no escape mass (or a saturated backbone) fall back to the backbone's support.
+        return Double.isFinite(getEscapeLogProbability()) || super.containsTree(tree);
+    }
+
+    @Override
+    public BigInteger getNumberOfTrees() {
+        BigInteger total = numberOfRootedTopologies(getNumberOfLeaves());
+        BigInteger k = super.getNumberOfTrees();
+        return total.compareTo(k) > 0 ? total : k;
+    }
+
+    /* -- SAMPLING (log-prob mixture; see class doc) -- */
+
+    @Override
+    public double sampleTreeLogProbability() {
+        double escapeLogProb = getEscapeLogProbability();
+        if (Double.isFinite(escapeLogProb) && random.nextDouble() < escapeMass) {
+            return escapeLogProb;
+        }
+        return log1mEscapeMass + super.sampleTreeLogProbability();
+    }
+
+    @Override
+    public double sampleTreeProbability() {
+        double escapeLogProb = getEscapeLogProbability();
+        if (Double.isFinite(escapeLogProb) && random.nextDouble() < escapeMass) {
+            return Math.exp(escapeLogProb);
+        }
+        return (1.0 - escapeMass) * super.sampleTreeProbability();
+    }
+
+    /* -- OTHER -- */
+
+    @Override
+    protected double getNumberOfParameters() {
+        // the CCD1 backbone's parameters plus the single escape parameter epsilon
+        return super.getNumberOfParameters() + 1;
+    }
+
+    @Override
+    public AbstractCCD copy() {
+        UniformEscapeCCD copy = new UniformEscapeCCD(this.getSizeOfLeavesArray(), false, this.escapeMass);
+        copy.baseTrees.add(this.getSomeBaseTree());
+        copy.numBaseTrees = this.getNumberOfBaseTrees();
+
+        AbstractCCD.buildCopy(this, copy);
+
+        return copy;
+    }
+
+    @Override
+    public String toString() {
+        return "UniformEscapeCCD [epsilon=" + escapeMass + "] " + super.toString();
+    }
+
+    /* -- STATIC HELPERS -- */
+
+    /**
+     * The number of distinct rooted bifurcating topologies on {@code n} labelled taxa, {@code (2n-3)!!}.
+     * Returns {@code 1} for {@code n <= 2}.
+     *
+     * @param n number of taxa
+     * @return {@code (2n-3)!!} as a {@link BigInteger}
+     */
+    public static BigInteger numberOfRootedTopologies(int n) {
+        BigInteger result = BigInteger.ONE;
+        for (int k = 2 * n - 3; k > 1; k -= 2) {
+            result = result.multiply(BigInteger.valueOf(k));
+        }
+        return result;
+    }
+
+    /**
+     * Natural logarithm of a {@link BigInteger}, robust to values far beyond {@code double} range
+     * (shifts the value into the mantissa range and corrects with the shift).
+     */
+    static double logBigInteger(BigInteger value) {
+        if (value.signum() <= 0) {
+            throw new IllegalArgumentException("log of non-positive BigInteger: " + value);
+        }
+        int shift = value.bitLength() - 1000; // keep the top ~1000 bits, well within double range
+        if (shift > 0) {
+            return Math.log(value.shiftRight(shift).doubleValue()) + shift * Math.log(2.0);
+        }
+        return Math.log(value.doubleValue());
+    }
+}

--- a/src/main/java/ccd/model/WrappedBeastTree.java
+++ b/src/main/java/ccd/model/WrappedBeastTree.java
@@ -6,14 +6,15 @@ import ccd.algorithms.TreeDistances;
 import ccd.model.bitsets.BitSet;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class WrappedBeastTree {
 
     private int count = 1;
 
-    private Tree wrappedTree;
+    protected Tree wrappedTree;
 
-    private BitSet[] cladeOfVertex;
+    protected BitSet[] cladeOfVertex;
 
     /** Matrix containing distances (#edges) between pairs of leaves. */
     private double[][] pathDistanceMatrix;
@@ -29,7 +30,7 @@ public class WrappedBeastTree {
         return wrappedTree;
     }
 
-    private BitSet initCladeBitSet(Node vertex) {
+    protected BitSet initCladeBitSet(Node vertex) {
         BitSet cladeAsBitSet = BitSet.newBitSet(wrappedTree.getLeafNodeCount());
         if (vertex.isLeaf()) {
             cladeAsBitSet.set(vertex.getNr());
@@ -39,7 +40,6 @@ public class WrappedBeastTree {
                 cladeAsBitSet.or(childBitSet);
             }
         }
-
         cladeOfVertex[vertex.getNr()] = cladeAsBitSet;
         return cladeAsBitSet;
     }
@@ -107,6 +107,9 @@ public class WrappedBeastTree {
         return false;
     }
 
+    /**
+     * @return A list of clades bitSet, excluding leaves, including root
+     */
     public ArrayList<BitSet> getNontrivialClades() {
         ArrayList<BitSet> clades = new ArrayList<>();
         for (int i = wrappedTree.getLeafNodeCount(); i < wrappedTree.getNodeCount(); i++) {

--- a/src/main/java/ccd/model/WrappedBeastTreeWithSampledAncestor.java
+++ b/src/main/java/ccd/model/WrappedBeastTreeWithSampledAncestor.java
@@ -1,0 +1,79 @@
+package ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import ccd.model.bitsets.BitSet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WrappedBeastTreeWithSampledAncestor extends WrappedBeastTree {
+
+    public WrappedBeastTreeWithSampledAncestor(Tree wrappedTree) {
+        super(wrappedTree);
+    }
+
+    @Override
+    protected BitSet initCladeBitSet(Node vertex) {
+        BitSet cladeAsBitSet;
+        if (vertex.isLeaf()) {
+            cladeAsBitSet = leafKey(vertex.getNr());
+        } else {
+            for (Node child : vertex.getChildren()) {
+                initCladeBitSet(child);
+            }
+            cladeAsBitSet = extendedSelfKey(vertex);
+        }
+        cladeOfVertex[vertex.getNr()] = cladeAsBitSet;
+        return cladeAsBitSet;
+    }
+
+    private BitSet leafKey(int taxonIndex) {
+        BitSet key = BitSet.newBitSet(2 * wrappedTree.getLeafNodeCount());
+        key.set(taxonIndex);
+        return key;
+    }
+
+    private BitSet extendedSelfKey(Node vertex) {
+        BitSet key = BitSet.newBitSet(2 * wrappedTree.getLeafNodeCount());
+        collectTaxaBits(vertex, key);
+        for (Node child : vertex.getChildren()) {
+            if (child.isLeaf() && child.getLength() == 0) {
+                key.set(wrappedTree.getLeafNodeCount() + child.getNr());
+            }
+        }
+        return key;
+    }
+
+    private void collectTaxaBits(Node vertex, BitSet key) {
+        if (vertex.isLeaf()) {
+            key.set(vertex.getNr());
+        } else {
+            for (Node child : vertex.getChildren()) {
+                collectTaxaBits(child, key);
+            }
+        }
+    }
+
+    public int getNumberOfSampledAncestors() {
+        int numberOfSampledAncestors = 0;
+        List<Node> leaves = wrappedTree.getExternalNodes();
+        for (Node leaf : leaves) {
+            if (leaf.getLength() == 0) {
+                numberOfSampledAncestors++;
+            }
+        }
+        return numberOfSampledAncestors;
+    }
+
+    public ArrayList<Node> getSampledAncestors() {
+        ArrayList<Node> sampledAncestorNodes = new ArrayList<>();
+        List<Node> leaves = wrappedTree.getExternalNodes();
+        for (Node leaf : leaves) {
+            if (leaf.getLength() == 0) {
+                sampledAncestorNodes.add(leaf);
+            }
+        }
+        return sampledAncestorNodes;
+    }
+}

--- a/src/main/java/ccd/model/bitsets/BitSet.java
+++ b/src/main/java/ccd/model/bitsets/BitSet.java
@@ -1,5 +1,7 @@
 package ccd.model.bitsets;
 
+import ccd.model.Clade;
+
 /**
  * Stripped down version of {@link java.util.BitSet} adapted for speedup;
  * safety checks on sizes removed and special child classes for small bitsets used.
@@ -153,6 +155,30 @@ public class BitSet implements Cloneable {
 
         int wordIndex = wordIndex(bitIndex);
         return ((words[wordIndex] & (1L << bitIndex)) != 0);
+    }
+
+    /**
+     * Returns the subset of the bitSet with specified from (inclusive) and to (exclusive) indices.
+     * The subset is a copy that is independent of the original bitSet.
+     *
+     * @param fromBitIndex the starting (inclusive) bit index
+     * @param toBitIndex   the ending (exclusive) bit index
+     * @return the subset of the bitSet given specified from (inclusive) and to (exclusive) indices
+     * @throws IndexOutOfBoundsException if the starting index is negative or the ending index < the starting index
+     */
+    public BitSet getSubset(int fromBitIndex, int toBitIndex) {
+        if (fromBitIndex < 0)
+            throw new IndexOutOfBoundsException("fromBitIndex < 0: " + fromBitIndex);
+        if (toBitIndex < fromBitIndex)
+            throw new IndexOutOfBoundsException("toBitIndex < fromBitIndex");
+
+        BitSet subset = new BitSet(toBitIndex - fromBitIndex);
+        for (int i = fromBitIndex; i < toBitIndex; i++) {
+            if (this.get(i)) {
+                subset.set(i - fromBitIndex);
+            }
+        }
+        return subset;
     }
 
     /**
@@ -501,7 +527,6 @@ public class BitSet implements Cloneable {
 
         return true;
     }
-
 
     /**
      * Returns the index of the last bit that is set to {@code true}

--- a/src/main/java/ccd/model/bitsets/BitSet128.java
+++ b/src/main/java/ccd/model/bitsets/BitSet128.java
@@ -107,6 +107,29 @@ public class BitSet128 extends BitSet {
     }
 
     /**
+     * Returns the subset of the bitSet with specified from (inclusive) and to (exclusive) indices.
+     *
+     * @param fromBitIndex the starting (inclusive) bit index
+     * @param toBitIndex the ending (exclusive) bit index
+     * @return the subset of the bitSet given specified from (inclusive) and to (exclusive) indices
+     * @throws IndexOutOfBoundsException if the starting index is negative or the ending index < the starting index
+     */
+    public BitSet128 getSubset(int fromBitIndex, int toBitIndex) {
+        if (fromBitIndex < 0)
+            throw new IndexOutOfBoundsException("fromBitIndex < 0: " + fromBitIndex);
+        if (toBitIndex < fromBitIndex)
+            throw new IndexOutOfBoundsException("toBitIndex < fromBitIndex");
+
+        BitSet128 subset = new BitSet128();
+        for (int i = fromBitIndex; i < toBitIndex; i++) {
+            if (this.get(i)) {
+                subset.set(i - fromBitIndex);
+            }
+        }
+        return subset;
+    }
+
+    /**
      * Performs a logical <b>OR</b> of this bit set with the bit set
      * argument. This bit set is modified so that a bit in it has the
      * value {@code true} if and only if it either already had the

--- a/src/main/java/ccd/model/bitsets/BitSet192.java
+++ b/src/main/java/ccd/model/bitsets/BitSet192.java
@@ -125,6 +125,29 @@ public class BitSet192 extends BitSet {
     }
 
     /**
+     * Returns the subset of the bitSet with specified from (inclusive) and to (exclusive) indices.
+     *
+     * @param fromBitIndex the starting (inclusive) bit index
+     * @param toBitIndex the ending (exclusive) bit index
+     * @return the subset of the bitSet given specified from (inclusive) and to (exclusive) indices
+     * @throws IndexOutOfBoundsException if the starting index is negative or the ending index < the starting index
+     */
+    public BitSet192 getSubset(int fromBitIndex, int toBitIndex) {
+        if (fromBitIndex < 0)
+            throw new IndexOutOfBoundsException("fromBitIndex < 0: " + fromBitIndex);
+        if (toBitIndex < fromBitIndex)
+            throw new IndexOutOfBoundsException("toBitIndex < fromBitIndex");
+
+        BitSet192 subset = new BitSet192();
+        for (int i = fromBitIndex; i < toBitIndex; i++) {
+            if (this.get(i)) {
+                subset.set(i - fromBitIndex);
+            }
+        }
+        return subset;
+    }
+
+    /**
      * Performs a logical <b>OR</b> of this bit set with the bit set
      * argument. This bit set is modified so that a bit in it has the
      * value {@code true} if and only if it either already had the

--- a/src/main/java/ccd/model/bitsets/BitSet256.java
+++ b/src/main/java/ccd/model/bitsets/BitSet256.java
@@ -156,6 +156,29 @@ public class BitSet256 extends BitSet {
     }
 
     /**
+     * Returns the subset of the bitSet with specified from (inclusive) and to (exclusive) indices.
+     *
+     * @param fromBitIndex the starting (inclusive) bit index
+     * @param toBitIndex the ending (exclusive) bit index
+     * @return the subset of the bitSet given specified from (inclusive) and to (exclusive) indices
+     * @throws IndexOutOfBoundsException if the starting index is negative or the ending index < the starting index
+     */
+    public BitSet256 getSubset(int fromBitIndex, int toBitIndex) {
+        if (fromBitIndex < 0)
+            throw new IndexOutOfBoundsException("fromBitIndex < 0: " + fromBitIndex);
+        if (toBitIndex < fromBitIndex)
+            throw new IndexOutOfBoundsException("toBitIndex < fromBitIndex");
+
+        BitSet256 subset = new BitSet256();
+        for (int i = fromBitIndex; i < toBitIndex; i++) {
+            if (this.get(i)) {
+                subset.set(i - fromBitIndex);
+            }
+        }
+        return subset;
+    }
+
+    /**
      * Performs a logical <b>OR</b> of this bit set with the bit set
      * argument. This bit set is modified so that a bit in it has the
      * value {@code true} if and only if it either already had the

--- a/src/main/java/ccd/model/bitsets/BitSet64.java
+++ b/src/main/java/ccd/model/bitsets/BitSet64.java
@@ -85,6 +85,29 @@ public class BitSet64 extends BitSet {
     }
 
     /**
+     * Returns the subset of the bitSet with specified from (inclusive) and to (exclusive) indices.
+     *
+     * @param fromBitIndex the starting (inclusive) bit index
+     * @param toBitIndex the ending (exclusive) bit index
+     * @return the subset of the bitSet given specified from (inclusive) and to (exclusive) indices
+     * @throws IndexOutOfBoundsException if the starting index is negative or the ending index < the starting index
+     */
+    public BitSet64 getSubset(int fromBitIndex, int toBitIndex) {
+        if (fromBitIndex < 0)
+            throw new IndexOutOfBoundsException("fromBitIndex < 0: " + fromBitIndex);
+        if (toBitIndex < fromBitIndex)
+            throw new IndexOutOfBoundsException("toBitIndex < fromBitIndex");
+
+        BitSet64 subset = new BitSet64();
+        for (int i = fromBitIndex; i < toBitIndex; i++) {
+            if (this.get(i)) {
+                subset.set(i - fromBitIndex);
+            }
+        }
+        return subset;
+    }
+
+    /**
      * Performs a logical <b>OR</b> of this bit set with the bit set
      * argument. This bit set is modified so that a bit in it has the
      * value {@code true} if and only if it either already had the

--- a/src/main/java/ccd/tools/CCDSampler.java
+++ b/src/main/java/ccd/tools/CCDSampler.java
@@ -11,11 +11,13 @@ import beastfx.app.util.TreeFile;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
+import java.util.List;
 import java.util.Random;
 
 import ccd.model.AbstractCCD;
 import ccd.model.CCDType;
 import ccd.model.HeightSettingStrategy;
+import ccd.model.KRegCCD;
 
 @Description("Allows to sample from a CCD{0,1} based on a input set of trees")
 public class CCDSampler extends Runnable {
@@ -25,6 +27,8 @@ public class CCDSampler extends Runnable {
     final public Input<CCDType> ccdTypeInput = new Input<>("ccdType", "type of CCD, e.g. CCD0 or CCD1", CCDType.CCD0, CCDType.values());
     final public Input<Integer> sampleSizeInput = new Input<>("length", "number of trees sampled from CCD", 1000);
     final public Input<Long> seedInput = new Input<>("seed", "seed for random for chain generation");
+    final public Input<Boolean> optimiseInput = new Input<>("optimise", "for ccdType KRegCCD only: select (alpha, mu) by cross-validated held-out tree probability instead of the defaults", false);
+    final public Input<Integer> foldsInput = new Input<>("folds", "number of cross-validation folds when optimise=true", 5);
 
     @Override
     public void initAndValidate() {
@@ -42,7 +46,16 @@ public class CCDSampler extends Runnable {
         Log.info.println("    output file: " + outputInput.get());
 
         TreeAnnotator.MemoryFriendlyTreeSet treeSet = CCDToolUtil.getTreeSet(treeInput, burnInPercentageInput.get());
-        AbstractCCD ccd = CCDToolUtil.getCCDTypeByName(treeSet, ccdTypeInput.get());
+        AbstractCCD ccd;
+        if (ccdTypeInput.get() == CCDType.KRegCCD && optimiseInput.get()) {
+            List<Tree> trees = CCDToolUtil.treesFromSet(treeSet);
+            Log.info.println("    selecting KRegCCD (alpha, mu) by " + foldsInput.get()
+                    + "-fold held-out cross-validation...");
+            ccd = KRegCCD.withOptimisedParameters(trees, foldsInput.get());
+            Log.info.println("    " + ccd);
+        } else {
+            ccd = CCDToolUtil.getCCDTypeByName(treeSet, ccdTypeInput.get());
+        }
 
         long seed = (seedInput.get() != null) ? seedInput.get() : System.currentTimeMillis();
         ccd.setRandom(new Random(seed));

--- a/src/main/java/ccd/tools/CCDToolUtil.java
+++ b/src/main/java/ccd/tools/CCDToolUtil.java
@@ -9,6 +9,7 @@ import ccd.model.CCD0;
 import ccd.model.CCD1;
 import ccd.model.CCD2;
 import ccd.model.CCDType;
+import ccd.model.KRegCCD;
 import ccd.model.OptRegCCD;
 import ccd.model.RegCCD;
 
@@ -71,6 +72,24 @@ public class CCDToolUtil {
         return ccd;
     }
 
+    /**
+     * Materialises all trees of a (burn-in-free) tree set into a list, e.g. for cross-validation
+     * that needs to partition the trees.
+     *
+     * @param treeSet the tree set to read
+     * @return all of its trees, in order
+     * @throws IOException if the underlying tree file cannot be read
+     */
+    public static java.util.List<beast.base.evolution.tree.Tree> treesFromSet(
+            TreeAnnotator.MemoryFriendlyTreeSet treeSet) throws IOException {
+        java.util.List<beast.base.evolution.tree.Tree> trees = new java.util.ArrayList<>();
+        treeSet.reset();
+        while (treeSet.hasNext()) {
+            trees.add(treeSet.next());
+        }
+        return trees;
+    }
+
     public static AbstractCCD getCCDTypeByName(TreeAnnotator.MemoryFriendlyTreeSet treeSet, CCDType ccdType) {
         AbstractCCD ccd;
         if (ccdType == CCDType.CCD0) {
@@ -83,6 +102,9 @@ public class CCDToolUtil {
             ccd = new RegCCD(treeSet);
         } else if (ccdType == CCDType.OptRegCCD) {
             ccd = new OptRegCCD(treeSet);
+        } else if (ccdType == CCDType.KRegCCD) {
+            ccd = new KRegCCD(treeSet, KRegCCD.DEFAULT_MU, KRegCCD.DEFAULT_ALPHA,
+                    KRegCCD.DEFAULT_RESERVE_DEPTH, KRegCCD.TailMode.BOUND);
         } else {
             throw new IllegalArgumentException("Illegal CCD type.");
         }

--- a/src/test/java/test/ccd/algorithms/KRegCCDParameterOptimiserTest.java
+++ b/src/test/java/test/ccd/algorithms/KRegCCDParameterOptimiserTest.java
@@ -1,0 +1,127 @@
+package test.ccd.algorithms;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.algorithms.regularisation.KRegCCDParameterOptimiser;
+import ccd.algorithms.regularisation.NNIHeldOutComparison.FoldAssignment;
+import ccd.model.KRegCCD;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests selecting KRegCCD's hyperparameters by held-out tree probability:
+ * {@link KRegCCD#getLogProbabilityOfTree(Tree, double)} re-scores at an arbitrary mu, and
+ * {@link KRegCCDParameterOptimiser} maximises the cross-validated held-out log-probability over
+ * {@code (alpha, mu)}.
+ */
+public class KRegCCDParameterOptimiserTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D", "E");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    /** A small, varied posterior-like sample with topological turnover, so cross-validation
+     * folds genuinely contain clades the training folds miss. */
+    private static List<Tree> trees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;"));
+        trees.add(parse("((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;"));
+        trees.add(parse("(((A:1,B:1):1,(C:1,D:1):1):1,E:1):0;"));
+        trees.add(parse("(((A:1,B:1):1,(C:1,D:1):1):1,E:1):0;"));
+        trees.add(parse("((((A:1,C:1):1,B:1):1,D:1):1,E:1):0;"));
+        trees.add(parse("((((A:1,B:1):1,D:1):1,C:1):1,E:1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:1):1,(D:1,E:1):1):0;"));
+        trees.add(parse("((((A:1,B:1):1,E:1):1,C:1):1,D:1):0;"));
+        return trees;
+    }
+
+    /**
+     * Scoring at an overridden mu on one backbone equals a freshly built NONE-tail model at that
+     * mu — this is what lets the optimiser sweep mu without rebuilding.
+     */
+    @Test
+    public void testMuOverrideMatchesFreshNoneModel() {
+        List<Tree> trees = trees();
+        // backbone built at one mu / tail mode; scoring overrides mu and uses tail = 0
+        KRegCCD built = new KRegCCD(trees, 0.0, 0.02, 0.4, 2, KRegCCD.TailMode.BOUND);
+        for (double mu : new double[]{0.005, 0.05, 0.2}) {
+            KRegCCD fresh = new KRegCCD(trees, 0.0, mu, 0.4, 2, KRegCCD.TailMode.NONE);
+            for (Tree t : trees) {
+                assertEquals(fresh.getLogProbabilityOfTree(t), built.getLogProbabilityOfTree(t, mu), 1e-9,
+                        "override scoring at mu=" + mu + " must match a fresh NONE model");
+            }
+        }
+    }
+
+    /**
+     * The optimiser returns valid parameters, its reported objective is the genuine cross-validated
+     * held-out log-probability at (alpha*, mu*), and that mu* is at least as good as the extreme mu
+     * values at the same alpha* — i.e. it really maximises held-out probability over mu.
+     */
+    @Test
+    public void testOptimiserMaximisesHeldOutOverMu() {
+        List<Tree> trees = trees();
+        KRegCCDParameterOptimiser.Params p = KRegCCDParameterOptimiser.optimise(trees, 4);
+
+        assertTrue(p.mu() > 0 && p.mu() < 1, "mu* must be a valid escape probability, got " + p.mu());
+        assertTrue(p.alpha() > 0, "alpha* must be positive, got " + p.alpha());
+        assertTrue(Double.isFinite(p.heldOutLogProb()), "held-out logP must be finite");
+
+        double atOptimum = KRegCCDParameterOptimiser.crossValidatedLogProb(
+                trees, 4, FoldAssignment.CONTIGUOUS, p.alpha(), p.mu());
+        assertEquals(p.heldOutLogProb(), atOptimum, 1e-6, "reported objective must be reproducible");
+
+        // compare against the two ends of the searched (valid) mu range
+        double atTinyMu = KRegCCDParameterOptimiser.crossValidatedLogProb(
+                trees, 4, FoldAssignment.CONTIGUOUS, p.alpha(), 1e-3);
+        double atCeilingMu = KRegCCDParameterOptimiser.crossValidatedLogProb(
+                trees, 4, FoldAssignment.CONTIGUOUS, p.alpha(), KRegCCD.MU_RELIABLE_MAX);
+        assertTrue(atOptimum >= atTinyMu - 1e-9,
+                "mu* should be at least as good as a near-zero mu (" + atOptimum + " vs " + atTinyMu + ")");
+        assertTrue(atOptimum >= atCeilingMu - 1e-9,
+                "mu* should be at least as good as the ceiling mu (" + atOptimum + " vs " + atCeilingMu + ")");
+        assertTrue(p.mu() <= KRegCCD.MU_RELIABLE_MAX + 1e-9,
+                "mu* must not exceed the reliability ceiling, got " + p.mu());
+    }
+
+    /**
+     * Held-out probability genuinely prefers some escape mass here: an interior mu beats mu -> 0,
+     * because the cross-validation folds contain clades their training folds miss (which a
+     * zero-escape model would assign probability zero / -inf).
+     */
+    @Test
+    public void testHeldOutPrefersNonzeroEscape() {
+        List<Tree> trees = trees();
+        double alpha = 0.4;
+        double atSmall = KRegCCDParameterOptimiser.crossValidatedLogProb(
+                trees, 4, FoldAssignment.STRIDED, alpha, 1e-3);
+        double atModerate = KRegCCDParameterOptimiser.crossValidatedLogProb(
+                trees, 4, FoldAssignment.STRIDED, alpha, 0.05);
+        assertTrue(atModerate > atSmall,
+                "moderate escape should beat near-zero escape when held-out trees have novel clades ("
+                        + atModerate + " vs " + atSmall + ")");
+    }
+
+    /** The factory builds a usable model at the optimised parameters: training trees score finite
+     * and it can sample. */
+    @Test
+    public void testFactoryBuildsUsableModel() {
+        List<Tree> trees = trees();
+        KRegCCD ccd = KRegCCD.withOptimisedParameters(trees, 4);
+        for (Tree t : trees) {
+            assertTrue(Double.isFinite(ccd.getLogProbabilityOfTree(t)),
+                    "training trees must score finite under the optimised model");
+        }
+        ccd.setRandom(new java.util.Random(1));
+        Tree sampled = ccd.sampleTree();
+        assertEquals(TAXA.size(), sampled.getLeafNodeCount(), "sampled tree must have all taxa");
+    }
+}

--- a/src/test/java/test/ccd/algorithms/NNICladeExpansionTest.java
+++ b/src/test/java/test/ccd/algorithms/NNICladeExpansionTest.java
@@ -1,0 +1,324 @@
+package test.ccd.algorithms;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.algorithms.NNICladeExpansion;
+import ccd.algorithms.NNICladeExpansion.NovelClade;
+import ccd.algorithms.NNICladeExpansion.PairingMode;
+import ccd.algorithms.NNICladeExpansion.Provenance;
+import ccd.algorithms.regularisation.CCDExpansion;
+import ccd.algorithms.regularisation.NNICladeExpander;
+import ccd.model.CCD0;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import ccd.model.NNIRegCCD;
+import ccd.model.bitsets.BitSet;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link NNICladeExpansion} against hand-computed NNI neighbourhoods.
+ */
+public class NNICladeExpansionTest {
+
+    private static final List<String> TAXA5 = Arrays.asList("A", "B", "C", "D", "E");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA5, newick, 1, false);
+    }
+
+    /** Taxa of a novel clade as a sorted letter string, e.g. "ABD". */
+    private static String name(BitSet taxa, Tree tree) {
+        StringBuilder sb = new StringBuilder();
+        String[] names = tree.getTaxaNames();
+        for (int i = taxa.nextSetBit(0); i >= 0; i = taxa.nextSetBit(i + 1)) {
+            sb.append(names[i]);
+        }
+        return sb.toString();
+    }
+
+    private static Set<String> novelNames(NNICladeExpansion exp, Tree tree) {
+        Set<String> names = new TreeSet<>();
+        for (NovelClade novel : exp.getNovelClades()) {
+            names.add(name(novel.taxa, tree));
+        }
+        return names;
+    }
+
+    /**
+     * Single tree (((A,B),C),D). The NNI neighbourhood of its three internal
+     * edges produces exactly the novel clades {ABD, CD, AC, BC}; with one tree
+     * the graph-wide and co-occurring modes must coincide.
+     */
+    @Test
+    public void testSingleTreeExactNeighbourhood() {
+        List<Tree> trees = new ArrayList<>();
+        Tree tree = parse("(((A:1,B:1):1,C:2):1,D:3):0;");
+        trees.add(tree);
+        CCD0 ccd = new CCD0(trees, 0.0);
+
+        NNICladeExpansion broad = new NNICladeExpansion(ccd, PairingMode.GRAPH_WIDE).compute();
+        NNICladeExpansion strict = new NNICladeExpansion(ccd, PairingMode.CO_OCCURRING).compute();
+
+        Set<String> expected = new TreeSet<>(Arrays.asList("ABD", "CD", "AC", "BC"));
+        assertEquals(expected, novelNames(broad, tree), "graph-wide novel clades");
+        assertEquals(expected, novelNames(strict, tree), "co-occurring novel clades");
+    }
+
+    /**
+     * Every novel clade's NNI seed split is {kept, sibling}, and both of those
+     * are clades that already exist in C - which is what makes the Phase 2
+     * extension feasible. Check this on the single-tree case.
+     */
+    @Test
+    public void testSeedSplitConstituentsExist() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:1):1,C:2):1,D:3):0;"));
+        CCD0 ccd = new CCD0(trees, 0.0);
+
+        NNICladeExpansion exp = new NNICladeExpansion(ccd, PairingMode.GRAPH_WIDE).compute();
+        for (NovelClade novel : exp.getNovelClades()) {
+            assertTrue(!novel.provenances.isEmpty(), "novel clade has a provenance");
+            for (Provenance prov : novel.provenances) {
+                assertTrue(ccd.getClades().contains(prov.kept()), "kept piece is in C");
+                assertTrue(ccd.getClades().contains(prov.sibling()), "sibling is in C");
+                // novel taxa == kept ∪ sibling
+                BitSet union = (BitSet) prov.kept().getCladeInBitsTaxaOnly().clone();
+                union.or(prov.sibling().getCladeInBitsTaxaOnly());
+                assertEquals(novel.taxa, union, "novel taxa equal kept ∪ sibling");
+            }
+        }
+    }
+
+    /**
+     * Two 5-taxon trees that share the clade {A,B,C} but split it differently
+     * ({AB,C} under {ABCD} in tree 1; {AC,B} under {ABCE} in tree 2). Graph-wide
+     * pairing recombines split contexts that never co-occurred, so it strictly
+     * exceeds the co-occurring (true sample-NNI) neighbourhood.
+     */
+    @Test
+    public void testGraphWideExceedsCoOccurring() {
+        List<Tree> trees = new ArrayList<>();
+        Tree t1 = parse("((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;");
+        Tree t2 = parse("((((A:1,C:1):1,B:1):1,E:1):1,D:1):0;");
+        trees.add(t1);
+        trees.add(t2);
+        CCD0 ccd = new CCD0(trees, 0.0);
+
+        NNICladeExpansion broad = new NNICladeExpansion(ccd, PairingMode.GRAPH_WIDE).compute();
+        NNICladeExpansion strict = new NNICladeExpansion(ccd, PairingMode.CO_OCCURRING).compute();
+
+        Set<String> broadNames = novelNames(broad, t1);
+        Set<String> strictNames = novelNames(strict, t1);
+
+        Set<String> expectedBroad = new TreeSet<>(Arrays.asList(
+                "ABD", "CD", "ACD", "BD", "ABE", "CE", "ACE", "BE", "DE", "BC"));
+        Set<String> expectedStrict = new TreeSet<>(Arrays.asList(
+                "DE", "ABD", "CD", "BC", "ACE", "BE"));
+        assertEquals(expectedBroad, broadNames, "graph-wide novel clades");
+        assertEquals(expectedStrict, strictNames, "co-occurring novel clades");
+
+        // strict neighbourhood is contained in the graph-wide one
+        assertTrue(broadNames.containsAll(strictNames), "strict ⊆ broad");
+
+        // the cross-tree recombinations are exactly the graph-wide extras
+        Set<String> onlyBroad = new TreeSet<>(broadNames);
+        onlyBroad.removeAll(strictNames);
+        assertEquals(new TreeSet<>(Arrays.asList("ACD", "BD", "ABE", "CE")), onlyBroad,
+                "graph-wide-only (cross-tree) clades");
+    }
+
+    /**
+     * The read-only novel-tree count must equal what the actual graph mutation
+     * (NNICladeExpander) produces for the same expansion. Checked on the
+     * single-tree neighbourhood.
+     */
+    @Test
+    public void testNovelTreeCountMatchesMutationSingleTree() {
+        Tree t = parse("(((A:1,B:1):1,C:2):1,D:3):0;");
+
+        List<Tree> trees1 = new ArrayList<>();
+        trees1.add(t);
+        CCD0 readOnly = new CCD0(trees1, 0.0);
+        BigInteger treesBefore = readOnly.getNumberOfTrees();
+        NNICladeExpansion exp = new NNICladeExpansion(readOnly, PairingMode.GRAPH_WIDE);
+        BigInteger predictedAfter = exp.getNumberOfTreesAfterExpansion();
+        BigInteger predictedNovel = exp.getNumberOfNovelTrees();
+
+        List<Tree> trees2 = new ArrayList<>();
+        trees2.add(parse("(((A:1,B:1):1,C:2):1,D:3):0;"));
+        CCD0 mutated = new CCD0(trees2, 0.0);
+        new NNICladeExpander(PairingMode.GRAPH_WIDE).expandClades(mutated);
+        BigInteger actualAfter = mutated.getNumberOfTrees();
+
+        assertEquals(actualAfter, predictedAfter, "predicted post-expansion tree count");
+        assertEquals(actualAfter.subtract(treesBefore), predictedNovel, "predicted novel tree count");
+        // CCD itself must remain unchanged by the read-only count
+        assertEquals(treesBefore, readOnly.getNumberOfTrees(), "read-only count must not mutate CCD");
+    }
+
+    /**
+     * Same check for the two-tree case in both pairing modes. Graph-wide and
+     * co-occurring expansions add different sets of clades, so the predicted
+     * tree counts must follow.
+     */
+    @Test
+    public void testNovelTreeCountMatchesMutationTwoTrees() {
+        String n1 = "((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;";
+        String n2 = "((((A:1,C:1):1,B:1):1,E:1):1,D:1):0;";
+
+        for (PairingMode mode : PairingMode.values()) {
+            List<Tree> trees1 = new ArrayList<>();
+            trees1.add(parse(n1));
+            trees1.add(parse(n2));
+            CCD0 readOnly = new CCD0(trees1, 0.0);
+            BigInteger treesBefore = readOnly.getNumberOfTrees();
+            NNICladeExpansion exp = new NNICladeExpansion(readOnly, mode);
+            BigInteger predictedAfter = exp.getNumberOfTreesAfterExpansion();
+            BigInteger predictedNovel = exp.getNumberOfNovelTrees();
+
+            List<Tree> trees2 = new ArrayList<>();
+            trees2.add(parse(n1));
+            trees2.add(parse(n2));
+            CCD0 mutated = new CCD0(trees2, 0.0);
+            new NNICladeExpander(mode).expandClades(mutated);
+            BigInteger actualAfter = mutated.getNumberOfTrees();
+
+            assertEquals(actualAfter, predictedAfter,
+                    "predicted post-expansion tree count [" + mode + "]");
+            assertEquals(actualAfter.subtract(treesBefore), predictedNovel,
+                    "predicted novel tree count [" + mode + "]");
+            assertEquals(treesBefore, readOnly.getNumberOfTrees(),
+                    "read-only count must not mutate CCD [" + mode + "]");
+        }
+    }
+
+    /**
+     * Post-(NNI + split-expansion) count must equal what running both passes
+     * for real (NNICladeExpander + CCDExpansion) produces. Two-tree case in
+     * both pairing modes.
+     */
+    @Test
+    public void testTreeCountAfterFullExpansionMatchesMutation() {
+        String n1 = "((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;";
+        String n2 = "((((A:1,C:1):1,B:1):1,E:1):1,D:1):0;";
+
+        for (PairingMode mode : PairingMode.values()) {
+            List<Tree> trees1 = new ArrayList<>();
+            trees1.add(parse(n1));
+            trees1.add(parse(n2));
+            CCD0 readOnly = new CCD0(trees1, 0.0);
+            BigInteger treesBefore = readOnly.getNumberOfTrees();
+            NNICladeExpansion exp = new NNICladeExpansion(readOnly, mode);
+            BigInteger predictedFull = exp.getNumberOfTreesAfterFullExpansion();
+            BigInteger predictedNovelFull = exp.getNumberOfNovelTreesAfterFullExpansion();
+
+            List<Tree> trees2 = new ArrayList<>();
+            trees2.add(parse(n1));
+            trees2.add(parse(n2));
+            CCD0 mutated = new CCD0(trees2, 0.0);
+            new NNICladeExpander(mode).expandClades(mutated);
+            new CCDExpansion().expandCCD(mutated);
+            BigInteger actualFull = mutated.getNumberOfTrees();
+
+            assertEquals(actualFull, predictedFull,
+                    "predicted post-full-expansion tree count [" + mode + "]");
+            assertEquals(actualFull.subtract(treesBefore), predictedNovelFull,
+                    "predicted novel-after-full tree count [" + mode + "]");
+            // NNI-only count must be <= full count, and full must be >= before
+            assertTrue(predictedFull.compareTo(exp.getNumberOfTreesAfterExpansion()) >= 0,
+                    "full expansion >= NNI-only [" + mode + "]");
+            assertTrue(predictedFull.compareTo(treesBefore) >= 0,
+                    "full expansion >= before [" + mode + "]");
+            // CCD itself must remain unchanged by the read-only count
+            assertEquals(treesBefore, readOnly.getNumberOfTrees(),
+                    "read-only count must not mutate CCD [" + mode + "]");
+        }
+    }
+
+    /**
+     * Probability mass on NNI-expanded trees must equal what a graph walk over
+     * the fully-built {@link NNIRegCCD} (NNI + CCDExpansion + regularisation)
+     * reports. Two-tree case in both pairing modes.
+     */
+    @Test
+    public void testProbabilityOfNNIExpandedTreesMatchesGraphWalk() {
+        String n1 = "((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;";
+        String n2 = "((((A:1,C:1):1,B:1):1,E:1):1,D:1):0;";
+        double alpha = 0.4;
+
+        for (PairingMode mode : PairingMode.values()) {
+            List<Tree> trees1 = new ArrayList<>();
+            trees1.add(parse(n1));
+            trees1.add(parse(n2));
+            CCD0 readOnly = new CCD0(trees1, 0.0);
+            double predicted = new NNICladeExpansion(readOnly, mode)
+                    .getProbabilityOfNNIExpandedTrees(alpha);
+
+            List<Tree> trees2 = new ArrayList<>();
+            trees2.add(parse(n1));
+            trees2.add(parse(n2));
+            NNIRegCCD reg = new NNIRegCCD(trees2, 0.0, mode, alpha);
+            double actual = 1.0 - existingOnlyMass(reg.getRootClade(), new HashMap<>());
+
+            assertEquals(actual, predicted, 1e-12,
+                    "P(NNI-expanded trees) [" + mode + "]");
+            // CCD itself must remain unchanged
+            assertEquals(2, readOnly.getNumberOfBaseTrees(),
+                    "read-only must not mutate CCD [" + mode + "]");
+        }
+    }
+
+    /** Total CCP-mass of trees rooted at c that use only existing clades. */
+    private static double existingOnlyMass(Clade c, Map<Clade, Double> memo) {
+        if (c.isNNIExpanded()) return 0.0;
+        if (c.isLeaf()) return 1.0;
+        Double cached = memo.get(c);
+        if (cached != null) return cached;
+        double m = 0.0;
+        for (CladePartition p : c.getPartitions()) {
+            Clade l = p.getChildClades()[0];
+            Clade r = p.getChildClades()[1];
+            if (l.isNNIExpanded() || r.isNNIExpanded()) continue;
+            m += p.getCCP() * existingOnlyMass(l, memo) * existingOnlyMass(r, memo);
+        }
+        memo.put(c, m);
+        return m;
+    }
+
+    /**
+     * Co-occurring mode needs all base trees; a CCD built without storing them
+     * should fail loudly rather than silently producing wrong results.
+     */
+    @Test
+    public void testCoOccurringRequiresBaseTrees() {
+        // empty CCD with storeBaseTrees = false: only the first tree is kept,
+        // so getBaseTrees() returns null and co-occurring mode cannot run
+        CCD0 ccd = new CCD0(5, false);
+        ccd.addTree(parse("((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;"));
+        ccd.addTree(parse("((((A:1,C:1):1,B:1):1,E:1):1,D:1):0;"));
+        ccd.initialize();
+
+        boolean threw = false;
+        try {
+            new NNICladeExpansion(ccd, PairingMode.CO_OCCURRING).compute();
+        } catch (IllegalStateException expected) {
+            threw = true;
+        }
+        // graph-wide still works without stored base trees
+        NNICladeExpansion broad = new NNICladeExpansion(ccd, PairingMode.GRAPH_WIDE).compute();
+        assertTrue(broad.getNumberOfNovelClades() >= 0);
+        assertTrue(threw, "co-occurring mode should require stored base trees");
+    }
+}

--- a/src/test/java/test/ccd/algorithms/NNIRegCCDOptimiserTest.java
+++ b/src/test/java/test/ccd/algorithms/NNIRegCCDOptimiserTest.java
@@ -1,0 +1,87 @@
+package test.ccd.algorithms;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.algorithms.NNICladeExpansion.PairingMode;
+import ccd.algorithms.regularisation.NNIRegCCDOptimiser;
+import ccd.algorithms.regularisation.NNIRegCCDOptimiser.Factor;
+import ccd.algorithms.regularisation.NNIRegCCDOptimiser.OptResult;
+import ccd.model.NNIRegCCD;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link NNIRegCCDOptimiser}: the closed-form trace scorer must agree
+ * with the baked model, and the grid search must run.
+ */
+public class NNIRegCCDOptimiserTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D", "E");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> trainingTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;"));
+        trees.add(parse("((((A:1,C:1):1,B:1):1,E:1):1,D:1):0;"));
+        return trees;
+    }
+
+    /**
+     * The trace-based log probability at (alpha, beta) must equal the baked
+     * NNIRegCCD's getLogProbabilityOfTree for the same (alpha, beta), for both
+     * covered and uncovered trees, in both pairing modes.
+     */
+    @Test
+    public void testTraceScorerMatchesBakedModel() {
+        List<Tree> training = trainingTrees();
+        List<Tree> testTrees = new ArrayList<>(training);
+        testTrees.add(parse("((((A:1,B:1):1,D:1):1,C:1):1,E:1):0;")); // unsampled clade {A,B,D}
+
+        double[][] params = {{0.4, 0.4}, {0.4, 0.02}, {0.25, 0.1}, {0.1, 0.5}};
+
+        for (PairingMode mode : PairingMode.values()) {
+            for (double[] ab : params) {
+                double alpha = ab[0], beta = ab[1];
+                NNIRegCCD model = new NNIRegCCD(training, 0.0, mode, alpha, beta);
+                List<List<Factor>> traces = NNIRegCCDOptimiser.extractTraces(model, testTrees);
+
+                for (int i = 0; i < testTrees.size(); i++) {
+                    double modelLP = model.getLogProbabilityOfTree(testTrees.get(i));
+                    if (modelLP == Double.NEGATIVE_INFINITY) {
+                        assertNull(traces.get(i),
+                                "uncovered tree should have a null trace [" + mode + "]");
+                    } else {
+                        assertEquals(modelLP, NNIRegCCDOptimiser.logProb(traces.get(i), alpha, beta), 1e-9,
+                                "trace logP must match baked model [" + mode
+                                        + ", a=" + alpha + ", b=" + beta + "]");
+                    }
+                }
+            }
+        }
+    }
+
+    /** The grid search runs and returns a finite optimum within the grid. */
+    @Test
+    public void testOptimiseRuns() {
+        List<Tree> training = trainingTrees();
+        double[] alphas = {0.1, 0.4, 1.0};
+        double[] betas = {0.01, 0.1, 0.4};
+
+        OptResult result = NNIRegCCDOptimiser.optimise(training, 2, PairingMode.CO_OCCURRING, alphas, betas);
+
+        assertTrue(Double.isFinite(result.meanLogProb()), "optimum should be finite");
+        assertTrue(result.alpha() >= 0.1 && result.alpha() <= 1.0, "alpha within grid");
+        assertTrue(result.beta() >= 0.01 && result.beta() <= 0.4, "beta within grid");
+        assertTrue(result.covered() > 0, "some held-out trees covered");
+    }
+}

--- a/src/test/java/test/ccd/algorithms/TreeDistancesTest.java
+++ b/src/test/java/test/ccd/algorithms/TreeDistancesTest.java
@@ -1,0 +1,184 @@
+package test.ccd.algorithms;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.algorithms.TreeDistances;
+import ccd.model.WrappedBeastTreeWithSampledAncestor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link TreeDistances#sampledAncestorRobinsonFoulds}.
+ *
+ * <p>All tests use 4-taxon trees on {A, B, C, D}. Branch length 0 marks a
+ * sampled ancestor (SA). The cuttable clade set of an SA tree is the set of
+ * taxa-only internal-node clades plus the singleton {i} for every non-SA
+ * leaf i; SA-RF is the size of the symmetric difference between the two
+ * trees' cuttable clade sets.
+ */
+public class TreeDistancesTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static WrappedBeastTreeWithSampledAncestor wrap(String newick) {
+        Tree t = new TreeParser(TAXA, newick, 1, false);
+        return new WrappedBeastTreeWithSampledAncestor(t);
+    }
+
+    /* ---------- Identity and symmetry ---------- */
+
+    @Test
+    public void testIdentityNoSA() {
+        WrappedBeastTreeWithSampledAncestor t = wrap("((A:1,B:1):1,(C:1,D:1):1):0;");
+        assertEquals(0, TreeDistances.sampledAncestorRobinsonFoulds(t, t));
+    }
+
+    @Test
+    public void testIdentityWithSA() {
+        WrappedBeastTreeWithSampledAncestor t = wrap("((A:1,B:0):1,(C:1,D:1):1):0;");
+        assertEquals(0, TreeDistances.sampledAncestorRobinsonFoulds(t, t));
+    }
+
+    @Test
+    public void testIdenticalTreesDistinctInstances() {
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:1,B:0):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,B:0):1,(C:1,D:1):1):0;");
+        assertEquals(0, TreeDistances.sampledAncestorRobinsonFoulds(t1, t2));
+    }
+
+    @Test
+    public void testSymmetry() {
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:1,B:0):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,C:1):1,(B:1,D:0):1):0;");
+        int d12 = TreeDistances.sampledAncestorRobinsonFoulds(t1, t2);
+        int d21 = TreeDistances.sampledAncestorRobinsonFoulds(t2, t1);
+        assertEquals(d12, d21, "SA-RF must be symmetric");
+    }
+
+    /* ---------- SA-only differences (same topology) ---------- */
+
+    @Test
+    public void testSingleSAFlipContributesOne() {
+        // Same topology, A is SA only in T1.
+        // T1 cuttable: internals {A,B},{C,D},{ABCD}; singletons {B},{C},{D}.
+        // T2 cuttable: same internals; singletons {A},{B},{C},{D}.
+        // Symm diff: {{A}} (only in T2). Distance = 1.
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:0,B:1):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,B:1):1,(C:1,D:1):1):0;");
+        assertEquals(1, TreeDistances.sampledAncestorRobinsonFoulds(t1, t2));
+    }
+
+    @Test
+    public void testSwappedSAOnSameTopologyContributesTwo() {
+        // Same topology; A is SA in T1, B is SA in T2.
+        // T1 singletons {B,C,D}; T2 singletons {A,C,D}. Symm diff = {{A},{B}}.
+        // Internals shared. Distance = 2.
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:0,B:1):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,B:0):1,(C:1,D:1):1):0;");
+        assertEquals(2, TreeDistances.sampledAncestorRobinsonFoulds(t1, t2));
+    }
+
+    /* ---------- Topology-only differences (no SAs) ---------- */
+
+    @Test
+    public void testTopologyOnlyDifference() {
+        // No SAs in either tree, so singletons coincide and only internal
+        // clades contribute. T1 internals {A,B},{C,D},{ABCD};
+        // T2 internals {A,C},{B,D},{ABCD}. Symm diff size = 4.
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:1,B:1):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,C:1):1,(B:1,D:1):1):0;");
+        assertEquals(4, TreeDistances.sampledAncestorRobinsonFoulds(t1, t2));
+    }
+
+    /* ---------- Combined topology + SA differences ---------- */
+
+    @Test
+    public void testCombinedTopologyAndSADifference() {
+        // T1 = ((A,B),(C,D)) with A,C SA  (one SA per cherry, valid).
+        //   Internals {A,B},{C,D},{ABCD}; singletons {B},{D}.
+        //   Cuttable = {{A,B},{C,D},{ABCD},{B},{D}}.
+        // T2 = ((A,D),(B,C)) with B,D SA  (one SA per cherry, valid).
+        //   Internals {A,D},{B,C},{ABCD}; singletons {A},{C}.
+        //   Cuttable = {{A,D},{B,C},{ABCD},{A},{C}}.
+        // Intersection = {{ABCD}}.
+        // Symm diff size = 4 + 4 = 8.
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:0,B:1):1,(C:0,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,D:0):1,(B:0,C:1):1):0;");
+        assertEquals(8, TreeDistances.sampledAncestorRobinsonFoulds(t1, t2));
+    }
+
+    /* ---------- Reduces to standard RF on SA-free trees ---------- */
+
+    @Test
+    public void testReducesToFullRFWhenNoSAs() {
+        // For two SA-free trees, SA-RF should equal 2 * (the existing
+        // halved robinsonsFouldDistance), because singletons are shared and
+        // internal clades contribute symmetrically.
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:1,B:1):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,C:1):1,(B:1,D:1):1):0;");
+        int saRF = TreeDistances.sampledAncestorRobinsonFoulds(t1, t2);
+        int halvedRF = TreeDistances.robinsonsFouldDistance(t1, t2);
+        assertEquals(2 * halvedRF, saRF,
+                "SA-RF on SA-free trees must equal full (unhalved) standard RF");
+    }
+
+    /* ---------- Pure topology RF (taxa-only, halved convention) ---------- */
+
+    @Test
+    public void testTopologyRFIgnoresSADifferences() {
+        // Same topology, different SA assignments → topology RF = 0.
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:0,B:1):1,(C:1,D:0):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,B:0):1,(C:0,D:1):1):0;");
+        assertEquals(0, TreeDistances.topologyRobinsonFoulds(t1, t2),
+                "topology RF must ignore SA flag differences when topology is identical");
+    }
+
+    @Test
+    public void testTopologyRFOnDifferentTopologies() {
+        // Different topologies, no SAs in either tree.
+        // T1 internals (taxa-only): {A,B}, {C,D}, {ABCD}
+        // T2 internals (taxa-only): {A,C}, {B,D}, {ABCD}
+        // |T1 \ T2| = 2 (the two cherries differ).
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:1,B:1):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,C:1):1,(B:1,D:1):1):0;");
+        assertEquals(2, TreeDistances.topologyRobinsonFoulds(t1, t2));
+    }
+
+    @Test
+    public void testTopologyRFOnDifferentTopologiesWithSAs() {
+        // Different topologies AND different SAs; the topology RF should be
+        // the same as if no SAs were present (it strips them).
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:0,B:1):1,(C:0,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,D:0):1,(B:0,C:1):1):0;");
+        // T1 internals (taxa-only): {A,B}, {C,D}, {ABCD}
+        // T2 internals (taxa-only): {A,D}, {B,C}, {ABCD}
+        // |T1 \ T2| = 2.
+        assertEquals(2, TreeDistances.topologyRobinsonFoulds(t1, t2));
+    }
+
+    @Test
+    public void testTopologyRFAgreesWithStandardRFOnSAFreeTrees() {
+        // When no SAs are present the wide bitsets of WrappedBeastTreeWithSampledAncestor
+        // collapse to taxa-only, so robinsonsFouldDistance and topologyRobinsonFoulds
+        // must agree.
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:1,B:1):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,C:1):1,(B:1,D:1):1):0;");
+        assertEquals(TreeDistances.robinsonsFouldDistance(t1, t2),
+                TreeDistances.topologyRobinsonFoulds(t1, t2),
+                "topologyRF must equal standard RF on SA-free trees");
+    }
+
+    @Test
+    public void testTopologyRFSymmetryOnBinaryTrees() {
+        // For binary trees on the same taxa, |T1 \ T2| = |T2 \ T1|.
+        WrappedBeastTreeWithSampledAncestor t1 = wrap("((A:0,B:1):1,(C:1,D:1):1):0;");
+        WrappedBeastTreeWithSampledAncestor t2 = wrap("((A:1,D:0):1,(B:1,C:1):1):0;");
+        assertEquals(TreeDistances.topologyRobinsonFoulds(t1, t2),
+                TreeDistances.topologyRobinsonFoulds(t2, t1),
+                "topology RF must be symmetric on binary trees");
+    }
+}

--- a/src/test/java/test/ccd/model/CCD0SJTest.java
+++ b/src/test/java/test/ccd/model/CCD0SJTest.java
@@ -1,0 +1,236 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import beastfx.app.inputeditor.BeautiPanelConfig;
+import ccd.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * CCD0SJ — clade-frequency parameterisation (CCD0) on the SJ extended-clade
+ * identity for sampled-ancestor trees.
+ *
+ * <p>Reuses the four-taxon worked example from {@code doc/sa-models.tex}:
+ * three sampled trees on taxa {A,B,C,D}, each with count 1:
+ * <pre>
+ *   Tree 1: ((A,B:0),(C,D))   — B is SA
+ *   Tree 2: ((A:0,B),(C,D))   — A is SA
+ *   Tree 3: (((A,B),C:0),D)   — C is SA
+ * </pre>
+ *
+ * <p>All three trees share the same root clade (taxa = ABCD, no SA at root),
+ * so the placeholder root has a single (variant, empty) partition with
+ * marginal 1. Under CCD0 normalisation, the root variant's partitions get
+ * scored by the product of child clade-frequencies; with the JS-style expand
+ * step ({@link CCD0SJ#expand()}) one new root-level partition
+ * ({A,B}-noSA, {C,D}-noSA) is added, plus two new partitions on
+ * {A,B,C}-SA on C pairing C with the SA-flagged {A,B} cherries.
+ *
+ * <p>Resulting tree probabilities:
+ * <pre>
+ *   P(Tree 1) = 2/9, P(Tree 2) = 2/9, P(Tree 3) = 1/9
+ * </pre>
+ * The remaining 4/9 mass is on three CCD0-expanded trees not in the sample.
+ */
+public class CCD0SJTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:0,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:0):1,D:2):0;"));
+        return trees;
+    }
+
+    private static List<Tree> unsampleTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("(((A:0,B:1):1,C:0):1,D:1):0;"));
+        trees.add(parse("(((A:1,B:0):1,C:0):1,D:1):0;"));
+        trees.add(parse("(((A:1,B:0):1,C:1):1,D:1):0;"));
+        trees.add(parse("(((A:0,B:1):1,C:1):1,D:1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:1):1,D:1):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testCCD0SJProbabilities() {
+        List<Tree> trees = sampleTrees();
+        CCD0SJ ccd = new CCD0SJ(trees, 0.0);
+
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        double p1 = ccd.getProbabilityOfTree(trees.get(0));
+        double p2 = ccd.getProbabilityOfTree(trees.get(1));
+        double p3 = ccd.getProbabilityOfTree(trees.get(2));
+
+        System.out.println("p1 = " + p1);
+
+        assertEquals(2.0 / 9.0, p1, 1e-9, "P(Tree 1)");
+        assertEquals(2.0 / 9.0, p2, 1e-9, "P(Tree 2)");
+        assertEquals(1.0 / 9.0, p3, 1e-9, "P(Tree 3)");
+    }
+
+    @Test
+    public void testCCD0CPProbabilities() {
+        List<Tree> trees = sampleTrees();
+        List<Tree> unsampledTrees = unsampleTrees();
+        CCD0CP ccd = new CCD0CP(trees, 0.0);
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+        double p1 = ccd.getProbabilityOfTree(trees.get(0));
+        double p2 = ccd.getProbabilityOfTree(trees.get(1));
+        double p3 = ccd.getProbabilityOfTree(trees.get(2));
+        double p4 = ccd.getProbabilityOfTree(unsampledTrees.get(0));
+        double p5 = ccd.getProbabilityOfTree(unsampledTrees.get(1));
+        double p6 = ccd.getProbabilityOfTree(unsampledTrees.get(2));
+        double p7 = ccd.getProbabilityOfTree(unsampledTrees.get(3));
+        double p8 = ccd.getProbabilityOfTree(unsampledTrees.get(4));
+        double p9 = ccd.getProbabilityOfTree(unsampledTrees.get(5));
+        System.out.println("sampled tree1 = " + p1);
+        System.out.println("sampled tree2 = " + p2);
+        System.out.println("sampled tree3 = " + p3);
+        System.out.println("unsampled 1 = " + p4);
+        System.out.println("unsampled 2 = " + p5);
+        System.out.println("unsampled 3 = " + p6);
+        System.out.println("unsampled 4 = " + p7);
+        System.out.println("unsampled 5 = " + p8);
+        System.out.println("unsampled 6 = " + p9);
+        double sum = p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
+        System.out.println("all trees prob sum = " + sum);
+    }
+
+    @Test
+    public void testRootCCPsSumToOne() {
+        List<Tree> trees = sampleTrees();
+        CCD0SJ ccd = new CCD0SJ(trees, 0.0);
+
+        // Single root variant → placeholder root partition CCP = 1.0.
+        assertEquals(1, ccd.getRootClade().getPartitions().size(),
+                "placeholder root has one (variant, empty) partition (only one root variant)");
+        assertEquals(1.0, ccd.getRootClade().getPartitions().get(0).getCCP(), 1e-9);
+
+        // The variant's own partitions (the actual root-split distribution)
+        // must sum to 1 under CCD0 normalisation. The variant is the non-empty
+        // child of the placeholder root partition.
+        CladePartition rootVariantPart = ccd.getRootClade().getPartitions().get(0);
+        ccd.model.Clade variant = rootVariantPart.getChildClades()[0].size() == 0
+                ? rootVariantPart.getChildClades()[1]
+                : rootVariantPart.getChildClades()[0];
+        double ccpSum = 0;
+        for (CladePartition p : variant.getPartitions()) {
+            ccpSum += p.getCCP();
+        }
+        assertEquals(1.0, ccpSum, 1e-9, "variant's partition CCPs sum to 1");
+    }
+
+    @Test
+    public void testLogProbabilityMatches() {
+        List<Tree> trees = sampleTrees();
+        CCD0SJ ccd = new CCD0SJ(trees, 0.0);
+
+        for (Tree t : trees) {
+            double p = ccd.getProbabilityOfTree(t);
+            double logp = ccd.getLogProbabilityOfTree(t);
+            assertEquals(Math.log(p), logp, 1e-9, "log/prob consistency");
+        }
+    }
+
+    /**
+     * With no SA leaves, CCD0SJ should produce the same tree probabilities as
+     * a standard CCD0 — the SA-flag bits are never set and the placeholder
+     * root collapses to a single (variant, empty) partition with CCP 1.
+     */
+    @Test
+    public void testNoSAReducesToCCD0() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:1,C:1):1,(B:1,D:1):1):0;"));
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+
+        CCD0 baseline = new CCD0(trees, 0.0);
+        CCD0SJ sj = new CCD0SJ(trees, 0.0);
+
+        for (Tree t : trees) {
+            double pBaseline = baseline.getProbabilityOfTree(t);
+            double pSj = sj.getProbabilityOfTree(t);
+            assertEquals(pBaseline, pSj, 1e-9,
+                    "CCD0SJ matches CCD0 when there are no SA leaves");
+        }
+    }
+
+    @Test
+    public void testSADetection() {
+        List<Tree> trees = sampleTrees();
+        CCD0SJ ccd = new CCD0SJ(trees, 0.0);
+
+        boolean foundSAClade = false;
+        for (ccd.model.Clade c : ccd.getClades()) {
+            if (ccd.isSampledAncestor(c)) {
+                foundSAClade = true;
+                break;
+            }
+        }
+        assertTrue(foundSAClade, "at least one clade should be flagged as carrying an SA");
+    }
+
+    /**
+     * Canonical signature for a sampled tree: Newick over taxon names with
+     * SA leaves (branch length 0) marked.
+     */
+    private static String signature(beast.base.evolution.tree.Node node) {
+        if (node.isLeaf()) {
+            String name = node.getID();
+            boolean sa = node.getLength() == 0.0;
+            return name + (sa ? ":SA" : "");
+        }
+        java.util.List<String> kids = new java.util.ArrayList<>();
+        for (beast.base.evolution.tree.Node c : node.getChildren()) {
+            kids.add(signature(c));
+        }
+        java.util.Collections.sort(kids);
+        return "(" + kids.get(0) + "," + kids.get(1) + ")";
+    }
+
+    @Test
+    public void testMAPTreePicksDominantVariant() {
+        // Two trees with one root-split variant, one with the other; under
+        // CCD0SJ scoring (subtree clade-credibility mass), the duplicated
+        // variant has strictly greater MAP score and must win.
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:0):1,D:2):0;"));
+
+        CCD0SJ ccd = new CCD0SJ(trees, 0.0);
+        Tree map = ccd.getMAPTree();
+
+        assertNotNull(map);
+        assertEquals(signature(trees.get(0).getRoot()), signature(map.getRoot()),
+                "MAP tree should be the duplicated SA-on-B variant");
+    }
+}

--- a/src/test/java/test/ccd/model/CCD0Test.java
+++ b/src/test/java/test/ccd/model/CCD0Test.java
@@ -1,0 +1,187 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CCD0Test {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampledTreeListNonSA() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:1):1,C:2):1,D:3):0;"));
+        trees.add(parse("(((D:1,C:1):1,B:2):1,A:3):0;"));
+        return trees;
+    }
+
+    private static List<Tree> sampledTreeListSA() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:1):1,C:2):1,D:0):0;"));
+        trees.add(parse("(((D:1,C:1):1,B:2):1,A:0):0;"));
+        // trees.add(parse("((A:1,C:1):1,(B:1,D:1):1):0;"));
+        // trees.add(parse("(((D:1,C:1):1,B:2):1,A:1):0;"));
+        return trees;
+    }
+
+    private static TreeAnnotator.MemoryFriendlyTreeSet sampledTreeSetNonSA() throws IOException {
+        String dataPath = "/Users/zyan598/Documents/GitHub/CCD_sampled_ancestor/example_trees/ccd0_nonSA.trees";
+        TreeAnnotator.MemoryFriendlyTreeSet treeSet = new TreeAnnotator().new MemoryFriendlyTreeSet(dataPath, 0);
+        return treeSet;
+    }
+
+    private static List<Tree> unsampledTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testNonSA() throws IOException {
+        List<Tree> treeList = sampledTreeListNonSA();
+        List<Tree> unsampledTreeList = unsampledTreeList();
+        CCD0 ccd = new CCD0(treeList, 0);
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+        double p1 = ccd.getProbabilityOfTree(unsampledTreeList.get(0));
+        System.out.println("unsampled tree prob = " + p1);
+    }
+
+    @Test
+    public void testCCD0CP() throws IOException {
+        List<Tree> treeList = sampledTreeListSA();
+        List<Tree> unsampledTreeList = unsampledTreeList();
+        CCD0CP ccd = new CCD0CP(treeList, 0);
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+        double p1 = ccd.getProbabilityOfTree(unsampledTreeList.get(0));
+        System.out.println("p1 = " + p1);
+    }
+
+    @Test
+    public void testCCD0SJ() throws IOException {
+        List<Tree> treeList = sampledTreeListSA();
+        List<Tree> unsampledTreeList = unsampledTreeList();
+        CCD0SJ ccd = new CCD0SJ(treeList, 0);
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+        double p1 = ccd.getProbabilityOfTree(unsampledTreeList.get(0));
+        System.out.println("p1 = " + p1);
+    }
+
+    // @Test
+    // public void testCCD0CP2() throws IOException {
+    //     List<Tree> treeList = sampledTreeList2();
+    //     List<Tree> unsampledTreeList = unsampledTreeList();
+    //     TreeAnnotator.MemoryFriendlyTreeSet treeSet = sampledTreeSet();
+    //     CCD0CP ccd = new CCD0CP(treeSet);
+    //     for (Clade clade : ccd.getClades()) {
+    //         System.out.println(clade);
+    //         for (CladePartition p : clade.getPartitions()) {
+    //             System.out.println(p);
+    //         }
+    //     }
+    //     double p1 = ccd.getProbabilityOfTree(unsampledTreeList.get(0));
+    //     double p2 = ccd.getProbabilityOfTree(treeList.get(0));
+    //     double p3 = ccd.getProbabilityOfTree(treeList.get(1));
+    //     System.out.println("sampled tree 1 = " + p2);
+    //     System.out.println("sampled tree 2 = " + p3);
+    //     System.out.println("unsampled tree 1 = " + p1);
+    // }
+    //
+    // @Test
+    // public void testCCD0SJ() throws IOException {
+    //     List<Tree> treeList = sampledTreeList();
+    //     TreeAnnotator.MemoryFriendlyTreeSet treeSet = sampledTreeSet();
+    //     CCD0SJ ccd = new CCD0SJ(treeSet);
+    //     double p1 = ccd.getProbabilityOfTree(treeList.get(0));
+    //     System.out.println("p1 = " + p1);
+    // }
+
+    /**
+     * The {@link ccd.model.AbstractCCD#AbstractCCD(List, double)} constructor
+     * has two branches; the {@code burnin == 0} branch must still set
+     * {@code numBaseTrees} so {@link Clade#getCladeCredibility()} is finite.
+     * Before the fix, {@code burnin == 0} left {@code numBaseTrees = 0}, so
+     * {@code numOccurrences / 0 = Infinity} for every clade and the CCD0
+     * constructor blew up with NaN inside {@code setPartitionProbabilities}.
+     */
+    @Test
+    public void testZeroBurninSetsBaseTreeCount() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:1,C:1):1,(B:1,D:1):1):0;"));
+
+        CCD0 ccd = new CCD0(trees, 0.0);
+
+        assertEquals(trees.size(), ccd.getNumberOfBaseTrees());
+        for (Clade c : ccd.getClades()) {
+            double cred = c.getCladeCredibility();
+            assertTrue(Double.isFinite(cred), "clade credibility must be finite, got " + cred + " for " + c);
+        }
+    }
+
+    /**
+     * Drives CCD0.setPartitionProbabilities into its log-sum-exp underflow
+     * branch (CCD0.java:860 "if (sumSubtreeProbabilities == 0)") and checks
+     * that the resulting partition CCPs are normalised. With the sign error
+     * at CCD0.java:894 (logSum = logMax - log(intermSum), should be +) the
+     * CCPs of the root's two partitions come out as 2.0 each instead of 0.5,
+     * so they sum to 4.0 rather than 1.0.
+     * <p>
+     * Setup: two 4-taxon trees that disagree on the root split, giving the
+     * root clade two partitions: {A,B}|{C,D} and {A,C}|{B,D}. Setting every
+     * non-leaf clade's parameter to 1e-200 makes each partition's product
+     * (1e-200 * 1e-200 = 1e-400) underflow to exactly 0, so the sum is 0 and
+     * the underflow branch fires.
+     */
+    @Test
+    public void testRootPartitionCCPsNormaliseUnderUnderflow() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:1,C:1):1,(B:1,D:1):1):0;"));
+
+        CCD0 ccd = new CCD0(trees, 0.0);
+
+        for (Clade clade : ccd.getClades()) {
+            if (!clade.isLeaf()) {
+                clade.setCladeParameter(1e-200);
+            }
+        }
+        ccd.resetSumCladeCredibilities();
+        ccd.setPartitionProbabilities(ccd.getRootClade(), true);
+
+        double ccpSum = 0.0;
+        for (CladePartition p : ccd.getRootClade().getPartitions()) {
+            ccpSum += p.getCCP();
+        }
+
+        assertEquals(1.0, ccpSum, 1e-9);
+    }
+}

--- a/src/test/java/test/ccd/model/CCD1CPTest.java
+++ b/src/test/java/test/ccd/model/CCD1CPTest.java
@@ -1,0 +1,116 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import beastfx.app.treeannotator.TreeAnnotator;
+import ccd.algorithms.TreeDistances;
+import ccd.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces the four-taxon worked example from doc/sa-models.tex.
+ * <p>
+ * Three sampled trees on taxa {A,B,C,D}, each with count 1:
+ * Tree 1: ((A,B:0),(C,D))   — B is SA
+ * Tree 2: ((A:0,B),(C,D))   — A is SA
+ * Tree 3: (((A,B),C:0),D)   — C is SA
+ * <p>
+ * Expected probabilities (in eighty-firsts):
+ * CP:  18, 18, 9
+ * SJ:  27, 27, 27
+ */
+
+public class CCD1CPTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:0,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:0):1,D:2):0;"));
+        return trees;
+    }
+
+    @Test
+    public void graphSizeTest() {
+        List<Tree> trees = sampleTreeList();
+        CCD1CP ccd1cp = new CCD1CP(trees, 0.0);
+        CCD1SJ ccd1sj = new CCD1SJ(trees, 0.0);
+        CCD0CP ccd0cp = new CCD0CP(trees, 0.0);
+        CCD0SJ ccd0sj = new CCD0SJ(trees, 0.0);
+        System.out.println("ccd1 CP # clades = " + ccd1cp.getNumberOfClades());
+        System.out.println("ccd1 CP # splits = " + ccd1cp.getNumberOfCladePartitions());
+        System.out.println("ccd1 SJ # clades = " + ccd1sj.getNumberOfClades());
+        for (Clade clade : ccd1sj.getClades()) {
+            System.out.println(clade);
+        }
+        System.out.println("ccd1 SJ # splits = " + ccd1sj.getNumberOfCladePartitions());
+        System.out.println("ccd0 CP # clades = " + ccd0cp.getNumberOfClades());
+        System.out.println("ccd0 CP # splits = " + ccd0cp.getNumberOfCladePartitions());
+        System.out.println("ccd0 SJ # clades = " + ccd0sj.getNumberOfClades());
+        System.out.println("ccd0 SJ # splits = " + ccd0sj.getNumberOfCladePartitions());
+    }
+
+    @Test
+    public void distanceTest() {
+        List<Tree> trees = sampleTreeList();
+        WrappedBeastTreeWithSampledAncestor tree1 = new WrappedBeastTreeWithSampledAncestor(trees.get(0));
+        WrappedBeastTreeWithSampledAncestor tree2 = new WrappedBeastTreeWithSampledAncestor(trees.get(1));
+        System.out.println("RF distance (SA WrappedBeastTree) = " + TreeDistances.robinsonsFouldDistance(tree1, tree2));
+        WrappedBeastTree tree1NonSA = new WrappedBeastTree(trees.get(0));
+        WrappedBeastTree tree2NonSA = new WrappedBeastTree(trees.get(1));
+        System.out.println("RF distance (non-SA WrappedBeastTree) = " + TreeDistances.robinsonsFouldDistance(tree1NonSA, tree2NonSA));
+    }
+
+    private static TreeAnnotator.MemoryFriendlyTreeSet sampleTreeSet() throws IOException {
+        String dataPath = "/Users/zyan598/Documents/GitHub/CCD_sampled_ancestor/example_trees/4taxa_alexei.trees";
+        TreeAnnotator.MemoryFriendlyTreeSet treeSet = new TreeAnnotator().new MemoryFriendlyTreeSet(dataPath, 0);
+        return treeSet;
+    }
+
+    private static double rounded(double x) {
+        return Math.round(x * 81 * 1e6) / 1e6 / 81.0;
+    }
+
+    @Test
+    public void treeSetTest() throws IOException {
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+                new java.io.File("/Users/zyan598/Documents/GitHub/CCD_sampled_ancestor/example_trees/4taxa_alexei.trees").exists(),
+                "skipped: SA example tree file not present on this machine");
+        TreeAnnotator.MemoryFriendlyTreeSet treeSet = sampleTreeSet();
+        // CCD1 ccd = new CCD1CP(treeSet, false);
+        // WrappedBeastTree mapTreeCCD1 = new WrappedBeastTree(ccd.getMAPTree());
+        // System.out.println("CCD MAP tree log prob = " + ccd.getMaxLogTreeProbability());
+    }
+
+    @Test
+    public void testCCD1CPProbabilities() {
+        List<Tree> trees = sampleTreeList();
+        CCD1CP cp = new CCD1CP(trees, 0.0);
+
+        for (Clade clade : cp.getClades()) {
+            System.out.println(clade);
+        }
+
+        double p1 = cp.getProbabilityOfTree(trees.get(0));
+        double p2 = cp.getProbabilityOfTree(trees.get(1));
+        double p3 = cp.getProbabilityOfTree(trees.get(2));
+
+        assertEquals(18.0 / 81.0, rounded(p1), 1e-9, "CP P(Tree 1)");
+        assertEquals(18.0 / 81.0, rounded(p2), 1e-9, "CP P(Tree 2)");
+        assertEquals(9.0 / 81.0, rounded(p3), 1e-9, "CP P(Tree 3)");
+
+    }
+}

--- a/src/test/java/test/ccd/model/CCD1SJTest.java
+++ b/src/test/java/test/ccd/model/CCD1SJTest.java
@@ -1,0 +1,165 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces the four-taxon worked example from doc/sa-models.tex.
+ * <p>
+ * Three sampled trees on taxa {A,B,C,D}, each with count 1:
+ * Tree 1: ((A,B:0),(C,D))   — B is SA
+ * Tree 2: ((A:0,B),(C,D))   — A is SA
+ * Tree 3: (((A,B),C:0),D)   — C is SA
+ * <p>
+ * Expected probabilities (in eighty-firsts):
+ * CP:  18, 18, 9
+ * SJ:  27, 27, 27
+ */
+public class CCD1SJTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:0,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:0):1,D:2):0;"));
+        return trees;
+    }
+
+    private static double rounded(double x) {
+        return Math.round(x * 81 * 1e6) / 1e6 / 81.0;
+    }
+
+    @Test
+    public void testCCD1SJProbabilities() {
+        List<Tree> trees = sampleTrees();
+        CCD1SJ sj = new CCD1SJ(trees, 0.0);
+
+        for (Clade clade : sj.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        double p1 = sj.getProbabilityOfTree(trees.get(0));
+        double p2 = sj.getProbabilityOfTree(trees.get(1));
+        double p3 = sj.getProbabilityOfTree(trees.get(2));
+
+        assertEquals(27.0 / 81.0, rounded(p1), 1e-9, "SJ P(Tree 1)");
+        assertEquals(27.0 / 81.0, rounded(p2), 1e-9, "SJ P(Tree 2)");
+        assertEquals(27.0 / 81.0, rounded(p3), 1e-9, "SJ P(Tree 3)");
+
+        assertEquals(1.0, p1 + p2 + p3, 1e-9, "SJ total mass on sampled trees");
+    }
+
+    @Test
+    public void testCCD1CPProbabilities() {
+        List<Tree> trees = sampleTrees();
+        CCD1CP cp = new CCD1CP(trees, 0.0);
+
+        double p1 = cp.getProbabilityOfTree(trees.get(0));
+        double p2 = cp.getProbabilityOfTree(trees.get(1));
+        double p3 = cp.getProbabilityOfTree(trees.get(2));
+
+        assertEquals(18.0 / 81.0, rounded(p1), 1e-9, "CP P(Tree 1)");
+        assertEquals(18.0 / 81.0, rounded(p2), 1e-9, "CP P(Tree 2)");
+        assertEquals(9.0 / 81.0, rounded(p3), 1e-9, "CP P(Tree 3)");
+    }
+
+    @Test
+    public void testSJLogProbabilityMatches() {
+        List<Tree> trees = sampleTrees();
+        CCD1SJ sj = new CCD1SJ(trees, 0.0);
+
+        for (Tree t : trees) {
+            double p = sj.getProbabilityOfTree(t);
+            double logp = sj.getLogProbabilityOfTree(t);
+            assertEquals(Math.log(p), logp, 1e-9, "log/prob consistency");
+        }
+    }
+
+    /**
+     * Canonical signature for a sampled tree: Newick over taxon names with
+     * SA leaves (branch length 0) marked. Used to bucket sampled trees by
+     * topology+SA-pattern for the empirical-distribution check.
+     */
+    private static String signature(beast.base.evolution.tree.Node node) {
+        if (node.isLeaf()) {
+            String name = node.getID();
+            boolean sa = node.getLength() == 0.0;
+            return name + (sa ? ":SA" : "");
+        }
+        java.util.List<String> kids = new java.util.ArrayList<>();
+        for (beast.base.evolution.tree.Node c : node.getChildren()) {
+            kids.add(signature(c));
+        }
+        java.util.Collections.sort(kids);
+        return "(" + kids.get(0) + "," + kids.get(1) + ")";
+    }
+
+    @Test
+    public void testSJSamplingMatchesAnalytical() {
+        List<Tree> trees = sampleTrees();
+        CCD1SJ sj = new CCD1SJ(trees, 0.0);
+
+        String sig1 = signature(trees.get(0).getRoot());
+        String sig2 = signature(trees.get(1).getRoot());
+        String sig3 = signature(trees.get(2).getRoot());
+
+        java.util.Map<String, Integer> counts = new java.util.HashMap<>();
+        int N = 30000;
+        for (int i = 0; i < N; i++) {
+            Tree sampled = sj.sampleTree();
+            String sig = signature(sampled.getRoot());
+            counts.merge(sig, 1, Integer::sum);
+        }
+
+        int c1 = counts.getOrDefault(sig1, 0);
+        int c2 = counts.getOrDefault(sig2, 0);
+        int c3 = counts.getOrDefault(sig3, 0);
+
+        // Sampled-only support: nothing outside the three known trees.
+        assertEquals(N, c1 + c2 + c3, "all samples land on one of the three sampled trees");
+
+        // Each tree gets ~1/3. With N=30000, std dev ~sqrt(N*p*(1-p))=~86.
+        // Tolerance 5σ ~ 430 → use 500 absolute, plenty of headroom.
+        double p1 = c1 / (double) N;
+        double p2 = c2 / (double) N;
+        double p3 = c3 / (double) N;
+        assertEquals(1.0 / 3.0, p1, 0.02, "empirical P(Tree 1)");
+        assertEquals(1.0 / 3.0, p2, 0.02, "empirical P(Tree 2)");
+        assertEquals(1.0 / 3.0, p3, 0.02, "empirical P(Tree 3)");
+    }
+
+    @Test
+    public void testMAPTreePicksDominantVariant() {
+        // Tree 1 appears twice → marginal 2/4; Tree 2 and Tree 3 once each → 1/4.
+        // With distinct counts there's no root-level tie and MAP must return
+        // the Tree-1 variant (including its SA pattern: B is the SA).
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:0,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:0):1,D:2):0;"));
+
+        CCD1SJ sj = new CCD1SJ(trees, 0.0);
+        Tree map = sj.getMAPTree();
+
+        assertEquals(signature(trees.get(0).getRoot()), signature(map.getRoot()),
+                "MAP tree should be the duplicated Tree-1 variant");
+    }
+}

--- a/src/test/java/test/ccd/model/FiveTaxaTest.java
+++ b/src/test/java/test/ccd/model/FiveTaxaTest.java
@@ -1,0 +1,43 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.CCD0CP;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FiveTaxaTest {
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D", "E");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:0,B:1):1,(C:1,(D:1,E:1):1):1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:0):1,(D:1,E:1):1):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testProbabilities() {
+        List<Tree> trees = sampleTreeList();
+        CCD0CP ccd = new CCD0CP(trees, 0.0);
+
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        System.out.println("p(tree1) = " + ccd.getProbabilityOfTree(trees.get(0)));
+        System.out.println("p(tree2) = " + ccd.getProbabilityOfTree(trees.get(1)));
+    }
+}

--- a/src/test/java/test/ccd/model/FourTaxaRootSATest1.java
+++ b/src/test/java/test/ccd/model/FourTaxaRootSATest1.java
@@ -1,0 +1,43 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.CCD0CP;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FourTaxaRootSATest1 {
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:1):1,C:1):1,D:0):0;"));
+        trees.add(parse("(((D:1,C:1):1,B:1):1,A:0):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testProbabilities() {
+        List<Tree> trees = sampleTreeList();
+        CCD0CP ccd = new CCD0CP(trees, 0.0);
+
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        System.out.println("p(tree1) = " + ccd.getProbabilityOfTree(trees.get(0)));
+        System.out.println("p(tree2) = " + ccd.getProbabilityOfTree(trees.get(1)));
+    }
+}

--- a/src/test/java/test/ccd/model/FourTaxaRootSATest2.java
+++ b/src/test/java/test/ccd/model/FourTaxaRootSATest2.java
@@ -1,0 +1,56 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FourTaxaRootSATest2 {
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTreeList1() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:0):1,C:1):1,D:0):0"));
+        trees.add(parse("(((A:0,B:1):1,C:1):1,D:1):0"));
+        trees.add(parse("((A:1,B:1):1,(C:1,D:0):1):0"));
+        return trees;
+    }
+
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:0,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("(((A:1,B:0):1,C:1):1,D:0):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testProbabilities() {
+        List<Tree> trees = sampleTreeList();
+        // CCD1CP ccd = new CCD1CP(trees, 0.0);
+        CCD0CP ccd = new CCD0CP(trees, 0.0);
+        // CCD1SJ ccd = new CCD1SJ(trees, 0.0);
+        // CCD0SJ ccd = new CCD0SJ(trees, 0.0);
+
+        System.out.println("num of partitions = " + ccd.getNumberOfCladePartitions());
+
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        System.out.println("p(tree1) = " + ccd.getProbabilityOfTree(trees.get(0)));
+        System.out.println("p(tree2) = " + ccd.getProbabilityOfTree(trees.get(1)));
+        System.out.println("p(tree3) = " + ccd.getProbabilityOfTree(trees.get(2)));
+    }
+}

--- a/src/test/java/test/ccd/model/FourTaxaTest1.java
+++ b/src/test/java/test/ccd/model/FourTaxaTest1.java
@@ -1,0 +1,45 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.CCD0CP;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FourTaxaTest1 {
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:1,B:0):1,(C:1,D:0):1):0;"));
+        trees.add(parse("(((A:1,B:0):1,C:1):1,D:1):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testProbabilities() {
+        List<Tree> trees = sampleTreeList();
+        CCD0CP ccd = new CCD0CP(trees, 0.0);
+
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        System.out.println("p(tree1) = " + ccd.getProbabilityOfTree(trees.get(0)));
+        System.out.println("p(tree2) = " + ccd.getProbabilityOfTree(trees.get(1)));
+        System.out.println("p(tree3) = " + ccd.getProbabilityOfTree(trees.get(2)));
+    }
+}

--- a/src/test/java/test/ccd/model/FourTaxaTest2.java
+++ b/src/test/java/test/ccd/model/FourTaxaTest2.java
@@ -1,0 +1,56 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.CCD0CP;
+import ccd.model.CCD1CP;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * * Tree 1: ((A:0,B),(C,D))   — A is SA
+ * * Tree 2: ((A,B:0),(C,D))   — B is SA
+ * * Tree 3: (((A,B),C:0),D)   — C is SA
+ * <p>
+ * Expected probabilities under CCD1 (in eighty-firsts):
+ * CP:  18, 18, 9
+ * SJ:  27, 27, 27
+ */
+
+public class FourTaxaTest2 {
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:0,B:1):1,(C:1,D:1):1):0;"));
+        trees.add(parse("((A:1,B:0):1,(C:1,D:1):1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:0):1,D:1):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testProbabilities() {
+        List<Tree> trees = sampleTreeList();
+        CCD0CP ccd = new CCD0CP(trees, 0.0);
+
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        System.out.println("p(tree1) = " + ccd.getProbabilityOfTree(trees.get(0)));
+        System.out.println("p(tree2) = " + ccd.getProbabilityOfTree(trees.get(1)));
+        System.out.println("p(tree3) = " + ccd.getProbabilityOfTree(trees.get(2)));
+    }
+}

--- a/src/test/java/test/ccd/model/GRegCCDTest.java
+++ b/src/test/java/test/ccd/model/GRegCCDTest.java
@@ -1,0 +1,95 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.GRegCCD;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Validates the GRegCCD model class: exact normalisation and P(T) = eps^(s(T))/Z, on enumerable sets. */
+public class GRegCCDTest {
+
+    private sealed interface T permits Leaf, Node {}
+    private record Leaf(String name) implements T {}
+    private record Node(T l, T r) implements T {}
+
+    private static String topo(T t) {
+        if (t instanceof Leaf lf) return lf.name();
+        Node n = (Node) t;
+        return "(" + topo(n.l()) + "," + topo(n.r()) + ")";
+    }
+
+    private static List<T> insertAll(T t, String x) {
+        List<T> out = new ArrayList<>();
+        out.add(new Node(new Leaf(x), t));
+        if (t instanceof Node n) {
+            for (T l2 : insertAll(n.l(), x)) out.add(new Node(l2, n.r()));
+            for (T r2 : insertAll(n.r(), x)) out.add(new Node(n.l(), r2));
+        }
+        return out;
+    }
+
+    private static List<T> allTopologies(List<String> taxa) {
+        List<T> trees = new ArrayList<>();
+        trees.add(new Leaf(taxa.get(0)));
+        for (int i = 1; i < taxa.size(); i++) {
+            List<T> next = new ArrayList<>();
+            for (T t : trees) next.addAll(insertAll(t, taxa.get(i)));
+            trees = next;
+        }
+        return trees;
+    }
+
+    private static T cat(String... names) {
+        T t = new Node(new Leaf(names[0]), new Leaf(names[1]));
+        for (int i = 2; i < names.length; i++) t = new Node(t, new Leaf(names[i]));
+        return t;
+    }
+
+    private void check(String label, List<String> taxa, List<T> sample, double eps) {
+        List<Tree> sampleTrees = new ArrayList<>();
+        for (T s : sample) sampleTrees.add(new TreeParser(taxa, topo(s) + ";", 1, false));
+        GRegCCD m = new GRegCCD(sampleTrees, eps);
+        double Z = Math.exp(m.getLogPartitionFunction());
+
+        TreeMap<Integer, double[]> byNovel = new TreeMap<>(); // s -> {count, sumP}
+        double sum = 0;
+        for (T t : allTopologies(taxa)) {
+            Tree tree = new TreeParser(taxa, topo(t) + ";", 1, false);
+            double p = m.getProbabilityOfTree(tree);
+            int s = m.novelSplitCount(tree);
+            // P(T) = (product of observed split counts) * eps^s / Z, so P*Z/eps^s is a positive integer.
+            double ratio = p * Z / Math.pow(eps, s);
+            assertEquals(Math.rint(ratio), ratio, 1e-7 * Math.max(ratio, 1.0),
+                    "P(T) not of the form (int) * eps^s / Z for " + topo(t));
+            sum += p;
+            byNovel.computeIfAbsent(s, k -> new double[2]);
+            byNovel.get(s)[0]++; byNovel.get(s)[1] += p;
+        }
+        System.out.printf("%n%s: %d taxa, eps=%.2f, Z=%.6f -> tiers (new splits: count):%n", label, taxa.size(), eps, Z);
+        for (var e : byNovel.entrySet())
+            System.out.printf("  %d: %.0f%n", e.getKey(), e.getValue()[0]);
+        System.out.printf("  SUM = %.12f%n", sum);
+        assertEquals(1.0, sum, 1e-10, "GRegCCD must be exactly normalised");
+    }
+
+    @Test
+    public void exactlyNormalised() {
+        check("4 taxa", Arrays.asList("A", "B", "C", "D"),
+                List.of(cat("A", "B", "C", "D"), cat("D", "C", "B", "A")), 0.1);
+        check("5 taxa +E", Arrays.asList("A", "B", "C", "D", "E"),
+                List.of(cat("A", "B", "C", "D", "E"), cat("D", "C", "B", "A", "E")), 0.1);
+        check("6 taxa +(E,F)", Arrays.asList("A", "B", "C", "D", "E", "F"),
+                List.of(new Node(cat("A", "B", "C", "D"), new Node(new Leaf("E"), new Leaf("F"))),
+                        new Node(cat("D", "C", "B", "A"), new Node(new Leaf("E"), new Leaf("F")))), 0.1);
+        // a different eps to confirm normalisation holds generally
+        check("5 taxa +E (eps=0.03)", Arrays.asList("A", "B", "C", "D", "E"),
+                List.of(cat("A", "B", "C", "D", "E"), cat("D", "C", "B", "A", "E")), 0.03);
+    }
+}

--- a/src/test/java/test/ccd/model/GRegZApproxTest.java
+++ b/src/test/java/test/ccd/model/GRegZApproxTest.java
@@ -1,0 +1,61 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.GRegCCD;
+import ccd.model.GRegZApprox;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Compares the large-n GRegZApprox partition function to GRegCCD's exact Z on small sets. */
+public class GRegZApproxTest {
+
+    private sealed interface T permits Leaf, Node {}
+    private record Leaf(String name) implements T {}
+    private record Node(T l, T r) implements T {}
+
+    private static String topo(T t) {
+        if (t instanceof Leaf lf) return lf.name();
+        Node n = (Node) t;
+        return "(" + topo(n.l()) + "," + topo(n.r()) + ")";
+    }
+
+    private static T cat(String... names) {
+        T t = new Node(new Leaf(names[0]), new Leaf(names[1]));
+        for (int i = 2; i < names.length; i++) t = new Node(t, new Leaf(names[i]));
+        return t;
+    }
+
+    private void compare(String label, List<String> taxa, List<T> sample, double eps) {
+        List<Tree> trees = new ArrayList<>();
+        for (T s : sample) trees.add(new TreeParser(taxa, topo(s) + ";", 1, false));
+        double exact = new GRegCCD(trees, eps).getLogPartitionFunction();
+        double approx = GRegZApprox.fromTrees(trees).logZ(eps);
+        double relErr = Math.abs(Math.exp(approx - exact) - 1.0);
+        System.out.printf("%-22s eps=%.3f  logZ exact=%.6f  approx=%.6f  relErr=%.3e%n",
+                label, eps, exact, approx, relErr);
+    }
+
+    @Test
+    public void approxMatchesExact() {
+        var t4 = Arrays.asList("A", "B", "C", "D");
+        var s4 = List.<T>of(cat("A", "B", "C", "D"), cat("D", "C", "B", "A"));
+        compare("4 taxa", t4, s4, 0.1);
+        compare("4 taxa", t4, s4, 0.01);
+
+        var t5 = Arrays.asList("A", "B", "C", "D", "E");
+        var s5 = List.<T>of(cat("A", "B", "C", "D", "E"), cat("D", "C", "B", "A", "E"));
+        compare("5 taxa +E", t5, s5, 0.1);
+        compare("5 taxa +E", t5, s5, 0.01);
+
+        var t6 = Arrays.asList("A", "B", "C", "D", "E", "F");
+        var s6 = List.<T>of(
+                new Node(cat("A", "B", "C", "D"), new Node(new Leaf("E"), new Leaf("F"))),
+                new Node(cat("D", "C", "B", "A"), new Node(new Leaf("E"), new Leaf("F"))));
+        compare("6 taxa +(E,F)", t6, s6, 0.1);
+        compare("6 taxa +(E,F)", t6, s6, 0.01);
+    }
+}

--- a/src/test/java/test/ccd/model/KRegCCDEntropyTest.java
+++ b/src/test/java/test/ccd/model/KRegCCDEntropyTest.java
@@ -1,0 +1,232 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.KRegCCD;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Compares the two KRegCCD entropy estimators -- the Monte-Carlo plug-in
+ * ({@link KRegCCD#getEntropyMonteCarlo(int)}) and the generalised Lewis recursion
+ * ({@link KRegCCD#getEntropyRecursive()}) -- against the <em>exact</em> entropy obtained by brute
+ * force over every rooted topology.
+ *
+ * <p>On four taxa with {@link KRegCCD.TailMode#NONE} the full-support model normalises to 1
+ * exactly (every blue-region boundary part is a leaf or cherry, so nothing reserves), which makes
+ * brute force a true gold standard: the recursion must match it to numerical precision and the
+ * Monte-Carlo estimate to within its standard error. This simultaneously validates both estimators
+ * and the score/sampler consistency they each rely on.
+ */
+public class KRegCCDEntropyTest {
+
+    /* --------------------------------------------------------------------- *
+     * four-taxon fixtures (model normalises exactly -> exact entropy available)
+     * --------------------------------------------------------------------- */
+
+    private static final List<String> TAXA4 = Arrays.asList("A", "B", "C", "D");
+
+    /** Observed clades AB, CD, ABC -- leaves room for novel clades, so escape entropy is nonzero. */
+    private static List<Tree> training4() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(new TreeParser(TAXA4, "(((A:1,B:1):1,C:1):1,D:1):0;", 1, false));
+        trees.add(new TreeParser(TAXA4, "((A:1,B:1):1,(C:1,D:1):1):0;", 1, false));
+        return trees;
+    }
+
+    /* --------------------------------------------------------------------- *
+     * five-taxon fixtures (boundary parts may reserve -> exact via brute force still,
+     * but the sampler/score split P != Q becomes observable)
+     * --------------------------------------------------------------------- */
+
+    private static final List<String> TAXA5 = Arrays.asList("A", "B", "C", "D", "E");
+
+    private static List<Tree> training5() {
+        List<Tree> trees = new ArrayList<>();
+        for (String nwk : new String[]{
+                "((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;",
+                "((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;",
+                "(((A:1,B:1):1,(C:1,D:1):1):1,E:1):0;",
+                "(((A:1,B:1):1,(C:1,D:1):1):1,E:1):0;",
+                "((((A:1,C:1):1,B:1):1,D:1):1,E:1):0;",
+                "(((A:1,B:1):1,C:1):1,(D:1,E:1):1):0;",
+        }) {
+            trees.add(new TreeParser(TAXA5, nwk, 1, false));
+        }
+        return trees;
+    }
+
+    /* --------------------------------------------------------------------- */
+
+    /** Exact entropy (and total mass) by brute force over all topologies: {@code -sum P log P}. */
+    private static double[] exactEntropyAndMass(KRegCCD ccd, List<Tree> topologies) {
+        double mass = 0.0;
+        double entropy = 0.0;
+        for (Tree t : topologies) {
+            double logp = ccd.getLogProbabilityOfTree(t);
+            double p = Math.exp(logp);
+            mass += p;
+            entropy -= p * logp;
+        }
+        return new double[]{entropy, mass};
+    }
+
+    /* --------------------------------------------------------------------- */
+
+    @Test
+    public void testRecursionMatchesExactOnFourTaxa() {
+        for (KRegCCD.NovelMode mode : KRegCCD.NovelMode.values()) {
+            KRegCCD ccd = new KRegCCD(training4(), 0.0, 0.05, 0.4, 2, KRegCCD.TailMode.NONE, mode);
+            List<Tree> topologies = allRootedTopologies(TAXA4);
+
+            double[] exact = exactEntropyAndMass(ccd, topologies);
+            assertEquals(1.0, exact[1], 1e-9,
+                    "model must normalise on four taxa [" + mode + "]");
+
+            double recursive = ccd.getEntropyRecursive();
+            assertEquals(exact[0], recursive, 1e-9,
+                    "recursion must equal the exact entropy [" + mode + "]");
+        }
+    }
+
+    @Test
+    public void testMonteCarloMatchesExactOnFourTaxa() {
+        for (KRegCCD.NovelMode mode : KRegCCD.NovelMode.values()) {
+            KRegCCD ccd = new KRegCCD(training4(), 0.0, 0.05, 0.4, 2, KRegCCD.TailMode.NONE, mode);
+            ccd.setRandom(new Random(20260614L));
+            List<Tree> topologies = allRootedTopologies(TAXA4);
+
+            double exact = exactEntropyAndMass(ccd, topologies)[0];
+            double[] mc = ccd.getEntropyMonteCarlo(300_000);
+
+            assertEquals(exact, mc[0], 5 * mc[1] + 1e-3,
+                    "Monte-Carlo estimate " + mc[0] + " +/- " + mc[1]
+                            + " must bracket the exact entropy " + exact + " [" + mode + "]");
+        }
+    }
+
+    @Test
+    public void testRecursionAndMonteCarloAgreeOnFiveTaxa() {
+        // On five taxa some boundary parts reserve, so the sampler's Q and the scored P diverge by
+        // O(mu) per reserving boundary part: the plug-in -E_Q[log P] sits slightly above the
+        // recursion's H(Q). They should still agree to within a few standard errors plus that small
+        // bias at the operating mu.
+        KRegCCD ccd = new KRegCCD(training5(), 0.0, 0.02, 0.4, 2, KRegCCD.TailMode.NONE);
+        ccd.setRandom(new Random(7L));
+
+        double recursive = ccd.getEntropyRecursive();
+        double[] mc = ccd.getEntropyMonteCarlo(300_000);
+
+        assertTrue(Double.isFinite(recursive) && recursive > 0, "recursion must give a positive entropy");
+        assertEquals(recursive, mc[0], 5 * mc[1] + 0.02,
+                "recursion " + recursive + " and Monte-Carlo " + mc[0] + " +/- " + mc[1]
+                        + " should agree up to the O(mu) sampler reservation");
+    }
+
+    @Test
+    public void testGetEntropyFollowsSamplingFidelity() {
+        // SELF_CONSISTENT: getEntropy() is exactly the deterministic recursion.
+        KRegCCD sc = new KRegCCD(training4(), 0.0, 0.05, 0.4, 2, KRegCCD.TailMode.NONE);
+        sc.setSamplingFidelity(KRegCCD.SamplingFidelity.SELF_CONSISTENT);
+        assertEquals(sc.getEntropyRecursive(), sc.getEntropy(), 1e-12,
+                "SELF_CONSISTENT getEntropy() must equal the exact recursion");
+
+        // FULL_SUPPORT: getEntropy() uses the Monte-Carlo plug-in. On four taxa there is no reserve
+        // tail, so the full-support distribution equals the self-consistent one and getEntropy()
+        // must match the exact entropy within Monte-Carlo error.
+        double exact = exactEntropyAndMass(
+                new KRegCCD(training4(), 0.0, 0.05, 0.4, 2, KRegCCD.TailMode.NONE),
+                allRootedTopologies(TAXA4))[0];
+        KRegCCD fs = new KRegCCD(training4(), 0.0, 0.05, 0.4, 2, KRegCCD.TailMode.SAMPLED);
+        fs.setSamplingFidelity(KRegCCD.SamplingFidelity.FULL_SUPPORT);
+        fs.setRandom(new Random(3L));
+        assertEquals(exact, fs.getEntropy(), 0.03,
+                "FULL_SUPPORT getEntropy() must match the exact entropy on four taxa (no tail)");
+    }
+
+    @Test
+    public void testLewisEntropyRejected() {
+        KRegCCD ccd = new KRegCCD(training4(), 0.0, 0.05, 0.4, 2, KRegCCD.TailMode.NONE);
+        assertThrows(UnsupportedOperationException.class, ccd::getEntropyLewis,
+                "the observed-only Lewis entropy must be rejected for a full-support model");
+    }
+
+    /* --------------------------------------------------------------------- *
+     * topology enumeration (all rooted binary trees over the taxa)
+     * --------------------------------------------------------------------- */
+
+    private static List<Tree> allRootedTopologies(List<String> taxa) {
+        List<Tree> trees = new ArrayList<>();
+        for (String shape : shapes(taxa)) {
+            trees.add(new TreeParser(taxa, shape + ";", 1, false));
+        }
+        return trees;
+    }
+
+    /** Newick fragments of every rooted binary tree over {@code taxa}; the first taxon is forced
+     * into the left side so each unordered split is counted once. */
+    private static List<String> shapes(List<String> taxa) {
+        List<String> out = new ArrayList<>();
+        if (taxa.size() == 1) {
+            out.add(taxa.get(0) + ":1");
+            return out;
+        }
+        String first = taxa.get(0);
+        List<String> rest = taxa.subList(1, taxa.size());
+        int n = rest.size();
+        for (int mask = 0; mask < (1 << n); mask++) {
+            List<String> left = new ArrayList<>();
+            left.add(first);
+            List<String> right = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                if ((mask & (1 << i)) != 0) {
+                    left.add(rest.get(i));
+                } else {
+                    right.add(rest.get(i));
+                }
+            }
+            if (right.isEmpty()) {
+                continue;
+            }
+            for (String l : shapes(left)) {
+                for (String r : shapes(right)) {
+                    out.add("(" + l + "," + r + "):1");
+                }
+            }
+        }
+        return out;
+    }
+
+    /* --------------------------------------------------------------------- *
+     * printed comparison (run directly: not part of the JUnit assertions)
+     * --------------------------------------------------------------------- */
+
+    public static void main(String[] args) {
+        System.out.printf("%-8s %-7s %-6s %-14s %-22s %-12s %-10s%n",
+                "taxa", "novel", "mu", "exact H", "Monte-Carlo H (+/-SE)", "recursion H", "totalMass");
+        compareRow(TAXA4, training4(), 0.05, KRegCCD.NovelMode.FLAT);
+        compareRow(TAXA4, training4(), 0.05, KRegCCD.NovelMode.SHARED);
+        compareRow(TAXA4, training4(), 0.01, KRegCCD.NovelMode.FLAT);
+        compareRow(TAXA5, training5(), 0.02, KRegCCD.NovelMode.FLAT);
+        compareRow(TAXA5, training5(), 0.05, KRegCCD.NovelMode.FLAT);
+    }
+
+    private static void compareRow(List<String> taxa, List<Tree> training, double mu,
+                                   KRegCCD.NovelMode mode) {
+        KRegCCD ccd = new KRegCCD(training, 0.0, mu, 0.4, 2, KRegCCD.TailMode.NONE, mode);
+        ccd.setRandom(new Random(1234L));
+        double[] exact = exactEntropyAndMass(ccd, allRootedTopologies(taxa));
+        double[] mc = ccd.getEntropyMonteCarlo(300_000);
+        double rec = ccd.getEntropyRecursive();
+        System.out.printf("%-8d %-7s %-6.2f %-14.6f %10.6f +/-%8.6f   %-12.6f %-10.6f%n",
+                taxa.size(), mode, mu, exact[0], mc[0], mc[1], rec, exact[1]);
+    }
+}

--- a/src/test/java/test/ccd/model/KRegCCDMapTreeTest.java
+++ b/src/test/java/test/ccd/model/KRegCCDMapTreeTest.java
@@ -1,0 +1,129 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.HeightSettingStrategy;
+import ccd.model.KRegCCD;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that {@link KRegCCD}'s discounted MAP DP returns the true full-support maximum.
+ *
+ * <p>The inherited DP maximises only the red-only log-CCP sum and omits the per-clade
+ * {@code log(1 - mu - tail(C))} escape discount, so it both overstates the maximum and can pick the
+ * wrong topology (the discount is incurred once per reservable internal clade, and reservability
+ * differs across topologies). On a taxon set small enough to enumerate every rooted topology we can
+ * pin the DP against a brute-force maximum of {@link KRegCCD#getLogProbabilityOfTree}.
+ */
+public class KRegCCDMapTreeTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D", "E");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    /** Training trees giving several size-3/4 observed clades (so reservable clades exist and the
+     * discount actually bites), with enough split variety that the MAP is non-trivial. */
+    private static List<Tree> trainingTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;"));
+        trees.add(parse("((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;"));
+        trees.add(parse("(((A:1,B:1):1,(C:1,D:1):1):1,E:1):0;"));
+        trees.add(parse("(((A:1,B:1):1,C:1):1,(D:1,E:1):1):0;"));
+        return trees;
+    }
+
+    private static KRegCCD build(double mu, KRegCCD.TailMode tailMode) {
+        return new KRegCCD(trainingTrees(), 0.0, mu, 0.4, 2, tailMode);
+    }
+
+    /**
+     * The discounted DP value equals the brute-force maximum of {@code getLogProbabilityOfTree} over
+     * every rooted topology, the returned MAP tree attains it, and {@code getMaxTreeProbability} is
+     * its exp -- across several mu and both tail modes (so the discount {@code 1 - mu - tail} varies).
+     */
+    @Test
+    public void testDiscountedMapMatchesBruteForce() {
+        for (KRegCCD.TailMode tail : new KRegCCD.TailMode[]{KRegCCD.TailMode.NONE, KRegCCD.TailMode.BOUND}) {
+            for (double mu : new double[]{0.005, 0.02, 0.05}) {
+                KRegCCD ccd = build(mu, tail);
+
+                double bruteMax = Double.NEGATIVE_INFINITY;
+                for (Tree t : allRootedTopologies()) {
+                    bruteMax = Math.max(bruteMax, ccd.getLogProbabilityOfTree(t));
+                }
+
+                double dpMax = ccd.getMaxLogTreeProbability();
+                assertEquals(bruteMax, dpMax, 1e-9,
+                        "discounted DP must equal the brute-force max log-prob (mu=" + mu + ", tail=" + tail + ")");
+
+                // The MAP tree the DP reports must actually attain that maximum.
+                Tree map = ccd.getMAPTree(HeightSettingStrategy.None);
+                assertEquals(dpMax, ccd.getLogProbabilityOfTree(map), 1e-9,
+                        "getLogProbabilityOfTree(getMAPTree()) must equal getMaxLogTreeProbability() (mu="
+                                + mu + ", tail=" + tail + ")");
+
+                assertEquals(Math.exp(dpMax), ccd.getMaxTreeProbability(), 1e-12,
+                        "getMaxTreeProbability must be exp(getMaxLogTreeProbability) (mu=" + mu + ", tail=" + tail + ")");
+
+                // No tree can beat the reported maximum.
+                for (Tree t : allRootedTopologies()) {
+                    assertTrue(ccd.getLogProbabilityOfTree(t) <= dpMax + 1e-9,
+                            "no topology may exceed the reported max (mu=" + mu + ", tail=" + tail + ")");
+                }
+            }
+        }
+    }
+
+    /* --------------------------------------------------------------------- */
+
+    private static List<Tree> allRootedTopologies() {
+        List<Tree> trees = new ArrayList<>();
+        for (String shape : shapes(TAXA)) {
+            trees.add(parse(shape + ";"));
+        }
+        return trees;
+    }
+
+    /** Newick fragments (with dummy branch lengths) of all rooted binary trees over {@code taxa};
+     * each unordered bipartition is counted once by forcing the first taxon into the left side. */
+    private static List<String> shapes(List<String> taxa) {
+        List<String> out = new ArrayList<>();
+        if (taxa.size() == 1) {
+            out.add(taxa.get(0) + ":1");
+            return out;
+        }
+        String first = taxa.get(0);
+        List<String> rest = taxa.subList(1, taxa.size());
+        int n = rest.size();
+        for (int mask = 0; mask < (1 << n); mask++) {
+            List<String> left = new ArrayList<>();
+            left.add(first);
+            List<String> right = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                if ((mask & (1 << i)) != 0) {
+                    left.add(rest.get(i));
+                } else {
+                    right.add(rest.get(i));
+                }
+            }
+            if (right.isEmpty()) {
+                continue; // left always holds `first`; require right non-empty too
+            }
+            for (String l : shapes(left)) {
+                for (String r : shapes(right)) {
+                    out.add("(" + l + "," + r + "):1");
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/src/test/java/test/ccd/model/KRegCCDSamplingTest.java
+++ b/src/test/java/test/ccd/model/KRegCCDSamplingTest.java
@@ -1,0 +1,266 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Node;
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.AbstractCCD;
+import ccd.model.HeightSettingStrategy;
+import ccd.model.KRegCCD;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that {@link KRegCCD} can <em>sample</em> from the full-support distribution it scores
+ * (not just the truncated red-only backbone the inherited sampler produces). The sampler escapes
+ * into blue regions that contain novel clades, and its empirical distribution matches
+ * {@code exp(getLogProbabilityOfTree)}.
+ *
+ * <p>On four taxa every blue region's boundary parts are leaves or cherries, which reserve no
+ * escape mass, so the sampler is <em>exact</em>: the model normalises to 1 and sampled-tree
+ * frequencies match the score.
+ */
+public class KRegCCDSamplingTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    /** Observed clades: AB, CD (size 2) and ABC (size 3); leaves room for novel clades like
+     * {A,C}, {A,B,D}, etc. */
+    private static List<Tree> trainingTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:1):1,C:1):1,D:1):0;"));
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+        return trees;
+    }
+
+    private static KRegCCD build(double mu, KRegCCD.TailMode tailMode) {
+        // k = 2 (default reserve depth); on four taxa this already covers every region order.
+        return new KRegCCD(trainingTrees(), 0.0, mu, 0.4, 2, tailMode);
+    }
+
+    /* --------------------------------------------------------------------- */
+
+    /**
+     * With the tail set to zero the full-support model is exactly normalised on four taxa:
+     * summing {@code exp(getLogProbabilityOfTree)} over every rooted binary topology gives 1.
+     * This is the strongest correctness check — it confirms the red discount, the blue-region
+     * weights, and the pathcount normalisation all line up.
+     */
+    @Test
+    public void testModelNormalisesOnFourTaxa() {
+        KRegCCD ccd = build(0.05, KRegCCD.TailMode.NONE);
+        double total = 0.0;
+        for (Tree t : allRootedTopologies()) {
+            double p = Math.exp(ccd.getLogProbabilityOfTree(t));
+            assertTrue(p > 0.0, "full support: every topology must have positive probability");
+            total += p;
+        }
+        assertEquals(1.0, total, 1e-6,
+                "exp(score) should sum to 1 over all topologies (exact on four taxa)");
+    }
+
+    /**
+     * Every sampled tree's stamped log-probability (accumulated in the node metadata while
+     * sampling) must equal {@link KRegCCD#getLogProbabilityOfTree} re-scoring that same tree.
+     * This validates the metadata stamping independently of Monte-Carlo noise, in both modes.
+     */
+    @Test
+    public void testSampleLogProbabilityMatchesScore() {
+        for (KRegCCD.SamplingFidelity fidelity : KRegCCD.SamplingFidelity.values()) {
+            KRegCCD ccd = build(0.05, KRegCCD.TailMode.NONE);
+            ccd.setSamplingFidelity(fidelity);
+            ccd.setRandom(new Random(42));
+            for (int i = 0; i < 2000; i++) {
+                Tree sampled = ccd.sampleTree(HeightSettingStrategy.None);
+                double stamped = (double) sampled.getRoot().getMetaData(AbstractCCD.LOG_PROB_SUBTREE_KEY);
+                double rescored = ccd.getLogProbabilityOfTree(sampled);
+                assertEquals(rescored, stamped, 1e-9,
+                        "stamped log-prob must equal getLogProbabilityOfTree [" + fidelity + "]");
+            }
+        }
+    }
+
+    /**
+     * Per-topology empirical frequencies match {@code exp(score)} on four taxa (exact target).
+     * At least one novel-clade topology must be both expected and observed, proving the sampler
+     * actually escapes the observed support.
+     */
+    @Test
+    public void testEmpiricalFrequenciesMatchScore() {
+        double mu = 0.05;
+        int n = 300_000;
+        KRegCCD ccd = build(mu, KRegCCD.TailMode.NONE);
+        ccd.setRandom(new Random(20260605L));
+
+        Map<String, Integer> counts = new HashMap<>();
+        for (int i = 0; i < n; i++) {
+            counts.merge(topologyKey(ccd.sampleTree(HeightSettingStrategy.None)), 1, Integer::sum);
+        }
+
+        boolean sawNovelTopology = false;
+        for (Tree t : allRootedTopologies()) {
+            double expected = Math.exp(ccd.getLogProbabilityOfTree(t));
+            String key = topologyKey(t);
+            double observed = counts.getOrDefault(key, 0) / (double) n;
+            // binomial standard error; only assert where we have enough samples to be meaningful
+            if (expected * n >= 100) {
+                double se = Math.sqrt(expected * (1 - expected) / n);
+                assertEquals(expected, observed, 5 * se + 0.002,
+                        "frequency of topology " + key + " should match exp(score)");
+            }
+            if (containsNovelClade(ccd, t) && expected * n >= 100) {
+                sawNovelTopology = true;
+                assertTrue(counts.getOrDefault(key, 0) > 0,
+                        "a novel-clade topology with non-trivial mass must actually be sampled");
+            }
+        }
+        assertTrue(sawNovelTopology,
+                "the sampler must produce novel-clade topologies (the whole point of full support)");
+    }
+
+    /**
+     * Aggregate calibration: the fraction of sampled trees that contain a novel clade matches the
+     * model's closed-form novel-clade probability {@link KRegCCD#getNovelCladeProbability()}.
+     */
+    @Test
+    public void testEmpiricalNovelFractionMatchesModel() {
+        double mu = 0.05;
+        int n = 300_000;
+        KRegCCD ccd = build(mu, KRegCCD.TailMode.NONE);
+        ccd.setRandom(new Random(7L));
+
+        double modelNovel = ccd.getNovelCladeProbability();
+        assertTrue(modelNovel > 0 && modelNovel < 1, "novel-clade probability should be interior");
+
+        int novel = 0;
+        for (int i = 0; i < n; i++) {
+            if (containsNovelClade(ccd, ccd.sampleTree(HeightSettingStrategy.None))) {
+                novel++;
+            }
+        }
+        double empirical = novel / (double) n;
+        double se = Math.sqrt(modelNovel * (1 - modelNovel) / n);
+        assertEquals(modelNovel, empirical, 5 * se + 0.003,
+                "empirical novel-clade fraction should match getNovelCladeProbability()");
+    }
+
+    /**
+     * Sampled trees are structurally valid (correct leaf count, positive branch lengths under
+     * height strategies that set heights), some contain novel clades, and all have positive
+     * probability under the model. Exercises the CommonAncestorHeights path that {@code CCDSampler}
+     * uses, plus the One strategy.
+     */
+    @Test
+    public void testSampledTreesAreValid() {
+        for (HeightSettingStrategy strategy :
+                List.of(HeightSettingStrategy.One, HeightSettingStrategy.CommonAncestorHeights)) {
+            KRegCCD ccd = build(0.1, KRegCCD.TailMode.BOUND);
+            ccd.setRandom(new Random(99));
+            boolean anyNovel = false;
+            for (int i = 0; i < 500; i++) {
+                Tree sampled = ccd.sampleTree(strategy);
+                assertEquals(TAXA.size(), sampled.getLeafNodeCount(),
+                        "sampled tree must have all taxa [" + strategy + "]");
+                assertPositiveBranches(sampled.getRoot(), strategy);
+                assertTrue(Math.exp(ccd.getLogProbabilityOfTree(sampled)) > 0.0,
+                        "sampled tree must have positive probability [" + strategy + "]");
+                anyNovel |= containsNovelClade(ccd, sampled);
+            }
+            assertTrue(anyNovel, "some sampled trees should contain a novel clade [" + strategy + "]");
+        }
+    }
+
+    /* --------------------------------------------------------------------- *
+     * helpers
+     * --------------------------------------------------------------------- */
+
+    private static boolean containsNovelClade(KRegCCD ccd, Tree t) {
+        return ccd.containsNovelClade(t);
+    }
+
+    /** Topology-invariant key: the sorted set of leaf-index sets at the internal nodes. */
+    private static String topologyKey(Tree t) {
+        List<String> clades = new ArrayList<>();
+        cladeKeys(t.getRoot(), clades);
+        Collections.sort(clades);
+        return clades.toString();
+    }
+
+    private static java.util.BitSet cladeKeys(Node v, List<String> clades) {
+        java.util.BitSet b = new java.util.BitSet();
+        if (v.isLeaf()) {
+            b.set(v.getNr());
+        } else {
+            for (Node c : v.getChildren()) {
+                b.or(cladeKeys(c, clades));
+            }
+            clades.add(b.toString());
+        }
+        return b;
+    }
+
+    private static void assertPositiveBranches(Node v, HeightSettingStrategy strategy) {
+        for (Node c : v.getChildren()) {
+            double bl = v.getHeight() - c.getHeight();
+            assertTrue(!Double.isNaN(bl) && bl > -1e-9,
+                    "branch length must be non-negative and finite [" + strategy + "], got " + bl);
+            assertPositiveBranches(c, strategy);
+        }
+    }
+
+    /** Every rooted binary topology over {@link #TAXA} (15 of them for four taxa). */
+    private static List<Tree> allRootedTopologies() {
+        List<Tree> trees = new ArrayList<>();
+        for (String shape : shapes(TAXA)) {
+            trees.add(parse(shape + ";"));
+        }
+        return trees;
+    }
+
+    /** Newick fragments (with dummy branch lengths) of all rooted binary trees over {@code taxa};
+     * each unordered bipartition is counted once by forcing the first taxon into the left side. */
+    private static List<String> shapes(List<String> taxa) {
+        List<String> out = new ArrayList<>();
+        if (taxa.size() == 1) {
+            out.add(taxa.get(0) + ":1");
+            return out;
+        }
+        String first = taxa.get(0);
+        List<String> rest = taxa.subList(1, taxa.size());
+        int n = rest.size();
+        for (int mask = 0; mask < (1 << n); mask++) {
+            List<String> left = new ArrayList<>();
+            left.add(first);
+            List<String> right = new ArrayList<>();
+            for (int i = 0; i < n; i++) {
+                if ((mask & (1 << i)) != 0) {
+                    left.add(rest.get(i));
+                } else {
+                    right.add(rest.get(i));
+                }
+            }
+            if (right.isEmpty()) {
+                continue; // left always holds `first`; require right non-empty too
+            }
+            for (String l : shapes(left)) {
+                for (String r : shapes(right)) {
+                    out.add("(" + l + "," + r + "):1");
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/src/test/java/test/ccd/model/KRegFourTaxaTest.java
+++ b/src/test/java/test/ccd/model/KRegFourTaxaTest.java
@@ -1,0 +1,76 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import ccd.model.KRegCCD;
+import ccd.model.RegCCD;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class KRegFourTaxaTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:1):1,C:1):1,D:1):0;"));
+        trees.add(parse("(((D:1,C:1):1,B:1):1,A:1):0;"));
+        return trees;
+    }
+
+    private static List<Tree> expandedTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));
+        return trees;
+    }
+
+    private static List<Tree> kregTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:1):1,D:1):1,C:1):0;"));
+        trees.add(parse("(((C:1,D:1):1,A:1):1,B:1):0;"));
+        trees.add(parse("(((A:1,C:1):1,B:1):1,D:1):0;"));
+        trees.add(parse("(((B:1,C:1):1,A:1):1,D:1):0;"));
+        trees.add(parse("(((B:1,C:1):1,D:1):1,A:1):0;"));
+        trees.add(parse("(((B:1,D:1):1,C:1):1,A:1):0;"));
+        trees.add(parse("(((A:1,D:1):1,B:1):1,C:1):0;"));
+        trees.add(parse("(((B:1,D:1):1,A:1):1,C:1):0;"));
+        trees.add(parse("(((A:1,C:1):1,D:1):1,B:1):0;"));
+        trees.add(parse("(((A:1,D:1):1,C:1):1,B:1):0;"));
+        trees.add(parse("((A:1,C:1):1,(B:1,D:1):1):0;"));
+        trees.add(parse("((A:1,D:1):1,(B:1,C:1):1):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testProbabilities() {
+        List<Tree> trees = sampleTreeList();
+        List<Tree> expandedTrees = expandedTrees();
+        List<Tree> kregTrees = kregTrees();
+        KRegCCD ccd = KRegCCD.withOptimisedParameters(trees);
+        // RegCCD ccd = new RegCCD(trees,0);
+
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        System.out.println("p(tree1) = " + ccd.getProbabilityOfTree(trees.get(0)));
+        System.out.println("p(tree2) = " + ccd.getProbabilityOfTree(trees.get(1)));
+        System.out.println("p(tree3) = " + ccd.getProbabilityOfTree(expandedTrees.get(0)));
+
+        for (int i = 0; i < kregTrees.size(); i++) {
+            System.out.println(ccd.getProbabilityOfTree(kregTrees.get(i)));
+        }
+    }
+}

--- a/src/test/java/test/ccd/model/MRegCCDTest.java
+++ b/src/test/java/test/ccd/model/MRegCCDTest.java
@@ -1,0 +1,196 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.CCD0;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import ccd.model.MRegCCD;
+import ccd.model.bitsets.BitSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates the one-parameter per-new-split {@link MRegCCD}: that with the full reserve depth it is an
+ * exactly normalised distribution on enumerable taxon sets, and that truncating the reserve without a
+ * tail correction super-normalises it (the artefact that made order-2 falsely appear to close the gap
+ * to KRegCCD in the RSV2 experiment).
+ */
+public class MRegCCDTest {
+
+    /* -- labelled rooted-binary-topology enumeration (as in GRegCCDTest) -- */
+    private sealed interface T permits Leaf, Node {}
+    private record Leaf(String name) implements T {}
+    private record Node(T l, T r) implements T {}
+
+    private static String topo(T t) {
+        if (t instanceof Leaf lf) return lf.name();
+        Node n = (Node) t;
+        return "(" + topo(n.l()) + "," + topo(n.r()) + ")";
+    }
+
+    private static List<T> insertAll(T t, String x) {
+        List<T> out = new ArrayList<>();
+        out.add(new Node(new Leaf(x), t));
+        if (t instanceof Node n) {
+            for (T l2 : insertAll(n.l(), x)) out.add(new Node(l2, n.r()));
+            for (T r2 : insertAll(n.r(), x)) out.add(new Node(n.l(), r2));
+        }
+        return out;
+    }
+
+    private static List<T> allTopologies(List<String> taxa) {
+        List<T> trees = new ArrayList<>();
+        trees.add(new Leaf(taxa.get(0)));
+        for (int i = 1; i < taxa.size(); i++) {
+            List<T> next = new ArrayList<>();
+            for (T t : trees) next.addAll(insertAll(t, taxa.get(i)));
+            trees = next;
+        }
+        return trees;
+    }
+
+    private static T cat(String... names) {
+        T t = new Node(new Leaf(names[0]), new Leaf(names[1]));
+        for (int i = 2; i < names.length; i++) t = new Node(t, new Leaf(names[i]));
+        return t;
+    }
+
+    private static List<Tree> trees(List<String> taxa, List<T> shapes) {
+        List<Tree> out = new ArrayList<>();
+        for (T s : shapes) out.add(new TreeParser(taxa, topo(s) + ";", 1, false));
+        return out;
+    }
+
+    private static double totalMass(MRegCCD m, List<String> taxa) {
+        double sum = 0.0;
+        for (T t : allTopologies(taxa)) {
+            Tree tree = new TreeParser(taxa, topo(t) + ";", 1, false);
+            sum += Math.exp(m.getLogProbabilityOfTree(tree));
+        }
+        return sum;
+    }
+
+    @Test
+    public void fullDepthIsExactlyNormalised() {
+        for (double mu : new double[]{0.02, 0.1, 0.25}) {
+            check5(mu);
+            check6(mu);
+        }
+    }
+
+    private void check5(double mu) {
+        List<String> taxa = Arrays.asList("A", "B", "C", "D", "E");
+        List<Tree> train = trees(taxa,
+                List.of(cat("A", "B", "C", "D", "E"), cat("D", "C", "B", "A", "E")));
+        MRegCCD m = new MRegCCD(train, 0.0, mu, taxa.size(), false); // full depth -> no omitted tail
+        double sum = totalMass(m, taxa);
+        System.out.printf("MRegCCD 5 taxa mu=%.2f full-depth SUM = %.12f%n", mu, sum);
+        assertEquals(1.0, sum, 1e-9, "MRegCCD at full reserve depth must be exactly normalised");
+    }
+
+    private void check6(double mu) {
+        List<String> taxa = Arrays.asList("A", "B", "C", "D", "E", "F");
+        List<Tree> train = trees(taxa,
+                List.of(new Node(cat("A", "B", "C", "D"), new Node(new Leaf("E"), new Leaf("F"))),
+                        new Node(cat("D", "C", "B", "A"), new Node(new Leaf("E"), new Leaf("F")))));
+        MRegCCD m = new MRegCCD(train, 0.0, mu, taxa.size(), false);
+        double sum = totalMass(m, taxa);
+        System.out.printf("MRegCCD 6 taxa mu=%.2f full-depth SUM = %.12f%n", mu, sum);
+        assertEquals(1.0, sum, 1e-9, "MRegCCD at full reserve depth must be exactly normalised");
+    }
+
+    @Test
+    public void m2EqualsCCD0ExpandedSplits() {
+        // A diverse but incomplete training set so many clades are observed without all their splits,
+        // creating recombinations (CCD0-expanded splits = M_2).
+        List<String> taxa = Arrays.asList("A", "B", "C", "D", "E", "F");
+        List<T> all = allTopologies(taxa);
+        List<T> picks = new ArrayList<>();
+        for (int i = 0; i < all.size(); i += 47) picks.add(all.get(i)); // ~20 trees spread across the space
+        List<Tree> train = trees(taxa, picks);
+
+        MRegCCD mreg = new MRegCCD(train, 0.0, 0.05);
+        CCD0 ccd0 = new CCD0(train, 0);
+
+        int checked = 0, withRecomb = 0;
+        for (Clade c : mreg.getClades()) {
+            if (c.size() < 2) continue;
+            BitSet bits = c.getCladeInBits();
+            int m2 = mreg.reserveCounts(bits)[2];
+
+            Clade c0 = ccd0.getClade(bits);
+            int expanded = 0;
+            for (CladePartition p : c0.getPartitions()) {
+                if (p.getNumberOfOccurrences() == 0) expanded++; // CCD0 split that was never observed
+            }
+            assertEquals(expanded, m2,
+                    "M_2 must equal the CCD0-expanded split count for clade " + bits);
+            checked++;
+            if (m2 > 0) withRecomb++;
+        }
+        System.out.printf("M_2 == CCD0-expanded splits verified on %d clades (%d with recombinations)%n",
+                checked, withRecomb);
+        assertTrue(withRecomb > 0, "test should exercise clades that actually have recombinations");
+    }
+
+    @Test
+    public void samplerMatchesScorer() {
+        // E_q[-log q(S)] = H(q): if the simulator draws from q AND reports the correct log q, the mean
+        // sampled -logp equals the entropy computed by enumeration with the scorer. Use the tail-OFF
+        // model so the self-consistent sampler and the scorer are the same distribution.
+        List<String> taxa = Arrays.asList("A", "B", "C", "D", "E", "F");
+        List<T> all = allTopologies(taxa);
+        List<T> picks = new ArrayList<>();
+        for (int i = 0; i < all.size(); i += 31) picks.add(all.get(i));
+        List<Tree> train = trees(taxa, picks);
+        MRegCCD m = new MRegCCD(train, 0.0, 0.1, taxa.size(), false); // full depth, tail off
+
+        // true entropy and normalisation by enumeration (scorer)
+        double sum = 0.0, H = 0.0;
+        for (T t : all) {
+            Tree tree = new TreeParser(taxa, topo(t) + ";", 1, false);
+            double logq = m.getLogProbabilityOfTree(tree);
+            double q = Math.exp(logq);
+            sum += q;
+            H -= q * logq;
+        }
+        assertEquals(1.0, sum, 1e-9, "tail-off full-depth model must be normalised");
+
+        // Monte-Carlo entropy from the sampler
+        int N = 300_000;
+        double s1 = 0.0, s2 = 0.0;
+        for (int i = 0; i < N; i++) {
+            double logp = m.sampleTreeLogProbability();
+            s1 += -logp;
+            s2 += logp * logp;
+        }
+        double hHat = s1 / N;
+        double se = Math.sqrt(Math.max(0, s2 / N - hHat * hHat) / N);
+        System.out.printf("MRegCCD sampler: H_enum=%.5f  H_MC=%.5f +/- %.5f (%.1f SE off)%n",
+                H, hHat, se, Math.abs(hHat - H) / se);
+        assertEquals(H, hHat, Math.max(5 * se, 0.01),
+                "sampler entropy must match the scorer's enumerated entropy");
+    }
+
+    @Test
+    public void truncatedReserveSuperNormalises() {
+        List<String> taxa = Arrays.asList("A", "B", "C", "D", "E", "F");
+        List<Tree> train = trees(taxa,
+                List.of(new Node(cat("A", "B", "C", "D"), new Node(new Leaf("E"), new Leaf("F"))),
+                        new Node(cat("D", "C", "B", "A"), new Node(new Leaf("E"), new Leaf("F")))));
+        double mu = 0.2;
+        double full = totalMass(new MRegCCD(train, 0.0, mu, taxa.size(), false), taxa);
+        double order2 = totalMass(new MRegCCD(train, 0.0, mu, 2, false), taxa); // M2 only, no tail
+        System.out.printf("MRegCCD 6 taxa mu=%.2f: full-depth SUM=%.9f  order-2 SUM=%.9f%n", mu, full, order2);
+        assertEquals(1.0, full, 1e-9, "full depth normalised");
+        assertTrue(order2 > 1.0 + 1e-4,
+                "order-2 reserve (no tail) must super-normalise (sum > 1), got " + order2);
+    }
+}

--- a/src/test/java/test/ccd/model/NNIRegCCDTest.java
+++ b/src/test/java/test/ccd/model/NNIRegCCDTest.java
@@ -1,0 +1,169 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.algorithms.NNICladeExpansion.PairingMode;
+import ccd.model.Clade;
+import ccd.model.CladePartition;
+import ccd.model.NNIRegCCD;
+import ccd.model.RegCCD;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that {@link NNIRegCCD} assigns nonzero probability to held-out trees
+ * containing an unsampled but NNI-reachable clade --- the case plain regCCD
+ * cannot cover --- while remaining a valid distribution.
+ */
+public class NNIRegCCDTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D", "E");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> trainingTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((((A:1,B:1):1,C:1):1,D:1):1,E:1):0;"));
+        trees.add(parse("((((A:1,C:1):1,B:1):1,E:1):1,D:1):0;"));
+        return trees;
+    }
+
+    // one NNI from training tree 1: clade {A,B,D} is not in the sample
+    private static Tree heldOutWithUnsampledClade() {
+        return parse("((((A:1,B:1):1,D:1):1,C:1):1,E:1):0;");
+    }
+
+    /**
+     * The held-out tree contains the clade {A,B,D}, which no training tree has.
+     * Plain regCCD gives it zero probability; NNIRegCCD (either pairing mode)
+     * gives it nonzero probability because the NNI clade expansion adds {A,B,D}
+     * and the split {A,B,C,D} -> {{A,B,D}, C}.
+     */
+    @Test
+    public void testHeldOutUnsampledCladeBecomesNonzero() {
+        List<Tree> training = trainingTrees();
+        Tree heldOut = heldOutWithUnsampledClade();
+
+        RegCCD reg = new RegCCD(training, 0.0);
+        double pReg = reg.getProbabilityOfTree(heldOut);
+        assertEquals(0.0, pReg, 0.0, "plain regCCD cannot cover the unsampled clade");
+
+        for (PairingMode mode : PairingMode.values()) {
+            NNIRegCCD nni = new NNIRegCCD(training, 0.0, mode);
+            double p = nni.getProbabilityOfTree(heldOut);
+            assertTrue(p > 0.0, "NNIRegCCD[" + mode + "] should cover the unsampled clade, got " + p);
+            assertTrue(p <= 1.0, "probability must be <= 1, got " + p);
+            assertTrue(nni.getNumberOfNNIClades() > 0, "expansion should add clades");
+        }
+    }
+
+    /** The training trees themselves must keep nonzero probability. */
+    @Test
+    public void testTrainingTreesRemainSupported() {
+        List<Tree> training = trainingTrees();
+        for (PairingMode mode : PairingMode.values()) {
+            NNIRegCCD nni = new NNIRegCCD(training, 0.0, mode);
+            for (Tree t : training) {
+                assertTrue(nni.getProbabilityOfTree(t) > 0.0,
+                        "training tree should stay supported under NNIRegCCD[" + mode + "]");
+            }
+        }
+    }
+
+    /**
+     * NNIRegCCD must remain a valid CCD: the conditional clade probabilities of
+     * every non-leaf clade's splits sum to 1.
+     */
+    @Test
+    public void testConditionalDistributionsNormalised() {
+        List<Tree> training = trainingTrees();
+        for (PairingMode mode : PairingMode.values()) {
+            List<NNIRegCCD> models = List.of(
+                    new NNIRegCCD(training, 0.0, mode),                 // single alpha
+                    new NNIRegCCD(training, 0.0, mode, 0.4, 0.02));     // two-level alpha/beta
+            for (NNIRegCCD nni : models) {
+                for (Clade clade : nni.getClades()) {
+                    if (clade.isLeaf()) {
+                        continue;
+                    }
+                    double sum = 0.0;
+                    for (CladePartition partition : clade.getPartitions()) {
+                        sum += partition.getCCP();
+                    }
+                    assertEquals(1.0, sum, 1e-9,
+                            "CCPs of clade " + clade + " should sum to 1 under NNIRegCCD[" + mode + "]");
+                }
+            }
+        }
+    }
+
+    /**
+     * Two-level smoothing with beta == alpha must reproduce single-alpha
+     * smoothing exactly (the AdditiveXY path collapses to AdditiveX).
+     */
+    @Test
+    public void testTwoLevelEqualsSingleAlphaWhenBetaEqualsAlpha() {
+        List<Tree> training = trainingTrees();
+        Tree heldOut = heldOutWithUnsampledClade();
+        double alpha = 0.4;
+
+        for (PairingMode mode : PairingMode.values()) {
+            NNIRegCCD single = new NNIRegCCD(training, 0.0, mode, alpha);
+            NNIRegCCD two = new NNIRegCCD(training, 0.0, mode, alpha, alpha);
+
+            assertEquals(single.getProbabilityOfTree(heldOut), two.getProbabilityOfTree(heldOut), 1e-12,
+                    "held-out prob should match for beta == alpha [" + mode + "]");
+            for (Tree t : training) {
+                assertEquals(single.getProbabilityOfTree(t), two.getProbabilityOfTree(t), 1e-12,
+                        "training prob should match for beta == alpha [" + mode + "]");
+            }
+        }
+    }
+
+    /**
+     * A smaller beta gives NNI-derived splits less mass: the held-out tree that
+     * relies on an NNI parent split loses probability, while a training tree
+     * built from observed splits at the same parent gains probability. Both stay
+     * positive.
+     */
+    @Test
+    public void testSmallerBetaShiftsMassToObservedSplits() {
+        List<Tree> training = trainingTrees();
+        Tree t1 = training.get(0);
+        Tree heldOut = heldOutWithUnsampledClade();
+        double alpha = 0.4;
+
+        NNIRegCCD big = new NNIRegCCD(training, 0.0, PairingMode.CO_OCCURRING, alpha, alpha);
+        NNIRegCCD small = new NNIRegCCD(training, 0.0, PairingMode.CO_OCCURRING, alpha, 0.01);
+
+        double pHeldBig = big.getProbabilityOfTree(heldOut);
+        double pHeldSmall = small.getProbabilityOfTree(heldOut);
+        assertTrue(pHeldSmall > 0, "held-out tree still covered with small beta");
+        assertTrue(pHeldSmall < pHeldBig, "smaller beta gives the NNI-reliant tree less mass");
+
+        double pTrainBig = big.getProbabilityOfTree(t1);
+        double pTrainSmall = small.getProbabilityOfTree(t1);
+        assertTrue(pTrainSmall > pTrainBig, "smaller beta gives the observed-split tree more mass");
+    }
+
+    /**
+     * Graph-wide pairing should cover at least as many clades as co-occurring,
+     * since the strict NNI neighbourhood is contained in the graph-wide one.
+     */
+    @Test
+    public void testGraphWideCoversAtLeastCoOccurring() {
+        List<Tree> training = trainingTrees();
+        NNIRegCCD broad = new NNIRegCCD(training, 0.0, PairingMode.GRAPH_WIDE);
+        NNIRegCCD strict = new NNIRegCCD(training, 0.0, PairingMode.CO_OCCURRING);
+        assertTrue(broad.getNumberOfNNIClades() >= strict.getNumberOfNNIClades(),
+                "graph-wide should add at least as many clades as co-occurring");
+    }
+}

--- a/src/test/java/test/ccd/model/ThreeTaxaRootSATest.java
+++ b/src/test/java/test/ccd/model/ThreeTaxaRootSATest.java
@@ -1,0 +1,57 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * * Tree 1: ((A,B),C)   — no SA
+ * * Tree 2: ((A,B),C:0)   — C is SA
+ * * Tree 3: ((A,B:0),C:0)   — B,C are SA
+ * <p>
+ * Expected probabilities under CCD1:
+ * CP:  2/9, 4/9, 2/9
+ * SJ:  1/3, 1/3, 1/3
+ */
+
+public class ThreeTaxaRootSATest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C");
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,C:1):0;"));
+        trees.add(parse("((A:1,B:1):1,C:0):0;"));
+        trees.add(parse("((A:1,B:0):1,C:0):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testProbabilities() {
+        List<Tree> trees = sampleTreeList();
+        CCD0CP ccd = new CCD0CP(trees, 0.0);
+        // CCD0SJ ccd = new CCD0SJ(trees, 0.0);
+
+        for (Clade clade : ccd.getClades()) {
+            System.out.println(clade);
+            for (CladePartition p : clade.getPartitions()) {
+                System.out.println(p);
+            }
+        }
+
+        System.out.println("p(tree1) = " + ccd.getProbabilityOfTree(trees.get(0)));
+        System.out.println("p(tree2) = " + ccd.getProbabilityOfTree(trees.get(1)));
+        System.out.println("p(tree3) = " + ccd.getProbabilityOfTree(trees.get(2)));
+    }
+}

--- a/src/test/java/test/ccd/model/UniformEscapeCCDTest.java
+++ b/src/test/java/test/ccd/model/UniformEscapeCCDTest.java
@@ -1,0 +1,121 @@
+package test.ccd.model;
+
+import beast.base.evolution.tree.Tree;
+import beast.base.evolution.tree.TreeParser;
+import ccd.model.UniformEscapeCCD;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The talk's worked example: two trees on four taxa, all 15 rooted topologies enumerated.
+ *
+ * <p>The plain CCD1 backbone built from {@code (((A,B),C),D)} and {@code (((D,C),B),A)} covers only
+ * those two topologies (its root only ever splits as {@code ABC|D} or {@code BCD|A}), each with
+ * probability 1/2. {@link UniformEscapeCCD} adds a lump of escape mass {@code epsilon} spread evenly
+ * over the remaining {@code M = 15 - 2 = 13} topologies, so:
+ * <pre>
+ *   the 2 in-support trees:  (1 - epsilon) * 1/2
+ *   the 13 off-support trees: epsilon / 13
+ *   total:                    (1 - epsilon) + epsilon = 1.
+ * </pre>
+ */
+public class UniformEscapeCCDTest {
+
+    private static final List<String> TAXA = Arrays.asList("A", "B", "C", "D");
+    private static final double EPS = 0.05;
+
+    private static Tree parse(String newick) {
+        return new TreeParser(TAXA, newick, 1, false);
+    }
+
+    /** The two sampled trees; the CCD1 backbone covers exactly these. */
+    private static List<Tree> sampleTreeList() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("(((A:1,B:1):1,C:1):1,D:1):0;"));
+        trees.add(parse("(((D:1,C:1):1,B:1):1,A:1):0;"));
+        return trees;
+    }
+
+    /** The other 13 rooted topologies on {A,B,C,D} (1 balanced split of the root + 12 others). */
+    private static List<Tree> offSupportTrees() {
+        List<Tree> trees = new ArrayList<>();
+        trees.add(parse("((A:1,B:1):1,(C:1,D:1):1):0;"));     // root split AB|CD (unobserved)
+        trees.add(parse("(((A:1,B:1):1,D:1):1,C:1):0;"));
+        trees.add(parse("(((C:1,D:1):1,A:1):1,B:1):0;"));
+        trees.add(parse("(((A:1,C:1):1,B:1):1,D:1):0;"));
+        trees.add(parse("(((B:1,C:1):1,A:1):1,D:1):0;"));
+        trees.add(parse("(((B:1,C:1):1,D:1):1,A:1):0;"));
+        trees.add(parse("(((B:1,D:1):1,C:1):1,A:1):0;"));
+        trees.add(parse("(((A:1,D:1):1,B:1):1,C:1):0;"));
+        trees.add(parse("(((B:1,D:1):1,A:1):1,C:1):0;"));
+        trees.add(parse("(((A:1,C:1):1,D:1):1,B:1):0;"));
+        trees.add(parse("(((A:1,D:1):1,C:1):1,B:1):0;"));
+        trees.add(parse("((A:1,C:1):1,(B:1,D:1):1):0;"));
+        trees.add(parse("((A:1,D:1):1,(B:1,C:1):1):0;"));
+        return trees;
+    }
+
+    @Test
+    public void testUniformEscapeDistribution() {
+        List<Tree> sampled = sampleTreeList();
+        List<Tree> offSupport = offSupportTrees();
+        UniformEscapeCCD ccd = new UniformEscapeCCD(sampled, 0.0, EPS);
+
+        // The backbone covers exactly the 2 sampled topologies; the full model covers all 15.
+        assertEquals(BigInteger.valueOf(15), ccd.getNumberOfTrees(), "full support over all 15 rooted topologies");
+        assertEquals(BigInteger.valueOf(13), ccd.getNumberOfOffSupportTrees(), "M = 15 - 2 off-support topologies");
+
+        // In-support trees: (1 - eps) * P_CCD1 = (1 - eps) * 1/2 each.
+        double inSupport = (1.0 - EPS) * 0.5;
+        for (Tree t : sampled) {
+            assertEquals(inSupport, ccd.getProbabilityOfTree(t), 1e-12, "in-support probability");
+            assertEquals(Math.log(inSupport), ccd.getLogProbabilityOfTree(t), 1e-9, "in-support log-probability");
+            assertTrue(ccd.containsTree(t), "in-support tree is contained");
+        }
+
+        // Off-support trees: each gets eps / 13.
+        double offProb = EPS / 13.0;
+        double escapeLogProb = Math.log(EPS) - Math.log(13.0);
+        assertEquals(escapeLogProb, ccd.getEscapeLogProbability(), 1e-12, "escape log-probability = log(eps/13)");
+        for (Tree t : offSupport) {
+            assertEquals(offProb, ccd.getProbabilityOfTree(t), 1e-12, "off-support probability = eps/13");
+            assertEquals(escapeLogProb, ccd.getLogProbabilityOfTree(t), 1e-9, "off-support log-probability");
+            assertTrue(ccd.containsTree(t), "off-support tree is still contained (full support)");
+        }
+
+        // The whole distribution is exactly normalised over all 15 topologies.
+        double total = 0.0;
+        for (Tree t : sampled) total += ccd.getProbabilityOfTree(t);
+        for (Tree t : offSupport) total += ccd.getProbabilityOfTree(t);
+        assertEquals(1.0, total, 1e-12, "the 15 topology probabilities sum to 1");
+    }
+
+    @Test
+    public void testZeroEscapeRecoversCCD1() {
+        // With epsilon = 0 the model is exactly the CCD1 backbone: off-support trees have probability 0.
+        UniformEscapeCCD ccd = new UniformEscapeCCD(sampleTreeList(), 0.0, 0.0);
+        for (Tree t : sampleTreeList()) {
+            assertEquals(0.5, ccd.getProbabilityOfTree(t), 1e-12, "backbone probability unchanged");
+        }
+        for (Tree t : offSupportTrees()) {
+            assertEquals(0.0, ccd.getProbabilityOfTree(t), 1e-12, "no escape mass => off-support probability 0");
+            assertTrue(Double.isInfinite(ccd.getLogProbabilityOfTree(t)), "off-support log-probability is -inf");
+        }
+    }
+
+    @Test
+    public void testNumberOfRootedTopologies() {
+        assertEquals(BigInteger.ONE, UniformEscapeCCD.numberOfRootedTopologies(2), "(2*2-3)!! = 1");
+        assertEquals(BigInteger.valueOf(3), UniformEscapeCCD.numberOfRootedTopologies(3), "3!! = 3");
+        assertEquals(BigInteger.valueOf(15), UniformEscapeCCD.numberOfRootedTopologies(4), "5!! = 15");
+        assertEquals(BigInteger.valueOf(105), UniformEscapeCCD.numberOfRootedTopologies(5), "7!! = 105");
+        assertEquals(BigInteger.valueOf(945), UniformEscapeCCD.numberOfRootedTopologies(6), "9!! = 945");
+    }
+}


### PR DESCRIPTION
Brings the full-support CCD regularisers (developed on the BEAST 2.7 line in CCD-Sophie) onto the `beast3` branch. Independent beast3 port, reconciled onto this branch's scaffolding (no changes to `pom.xml`, `module-info`, or `version.xml`).

## What's added
- **ccd.model:** `KRegCCD`, `MRegCCD`, `GRegCCD`/`GRegZApprox`, `NNIRegCCD`; the `UniformEscapeCCD` trivial full-coverage baseline; the `CCD0CP`/`CCD0SJ`/`CCD1CP`/`CCD1SJ` variants with `CPSupport`/`SJSupport`; sampled-ancestor support (`WrappedBeastTreeWithSampledAncestor`).
- **ccd.algorithms.regularisation:** KReg/MReg/NNIReg parameter optimisers and NNI clade expansion.
- **ccd.experiments.UniformEscapeComparison:** held-out logP + PIT calibration across CCD1/regCCD/KRegCCD/CCD1+ε; `doc/plot_pit.py` renders the full-coverage PIT histograms.
- Supporting enhancements to the shared base classes (`AbstractCCD`, `Clade`, `CladePartition`, `RegCCD`, …) that the regularisers build on.

## Bug fix
`CCD2(trees, burnin)` reimplemented the burn-in handling instead of delegating to `AbstractCCD` and failed to set `numBaseTrees` when `burnin == 0` (`CCD0`/`CCD1` set it via `super()`). Surfaced by the existing `CCDCoreTest`.

## Notes
- The three commons-math3 optimiser users are migrated to the `org.apache.commons.math4.legacy` package already required by beast3 — no new dependency.
- 45 new files, 24 updated source files; **104 tests pass**, including the pre-existing `CCDCoreTest`.
